### PR TITLE
新增执行器能力模型与动态控制 UI（平台侧 P1+P2）

### DIFF
--- a/app/controller/DeviceController.php
+++ b/app/controller/DeviceController.php
@@ -17,6 +17,7 @@ namespace app\controller;
 use app\model\Device;
 use app\service\DeviceService;
 use app\service\MqttCommandService;
+use app\service\ActuatorService;
 use app\service\AuditService;
 use support\Request;
 use OpenApi\Attributes as OA;
@@ -113,7 +114,13 @@ class DeviceController
             return api_error('无权访问该设备', 403, 1004);
         }
 
-        return api_success($device);
+        // 附带执行器当前状态（供前端动态控制 UI 初始化）
+        $data = $device->toArray();
+        $data['state'] = $device->capability
+            ? (ActuatorService::getState($device->id) ?? (object)[])
+            : (object)[];
+
+        return api_success($data);
     }
 
     /**
@@ -329,17 +336,16 @@ class DeviceController
             return api_error('指令 params 必须是对象', 422, 1000);
         }
 
-        // 仅透传 action 与 params，剥离其它无关字段，避免下发任意结构
-        $payload = ['action' => $action];
-        if (isset($input['params'])) {
-            $payload['params'] = $input['params'];
-        }
+        $params = isset($input['params']) ? $input['params'] : [];
 
-        $commandLog = MqttCommandService::sendCommand($id, $payload);
+        // 经执行器服务：按设备能力校验 → 合并/直发 → 状态双写 → 推 WS
+        // 校验失败抛 BusinessException，由全局异常处理器转为 JSON 错误响应
+        $commandLog = ActuatorService::applyCommand($device, $action, $params);
 
         AuditService::log($request, 'command_send', 'device', $id, [
             'request_id' => $commandLog->request_id,
-            'payload'    => $payload,
+            'action'     => $action,
+            'params'     => $params,
         ]);
 
         return api_success([

--- a/app/controller/admin/CapabilityTemplateController.php
+++ b/app/controller/admin/CapabilityTemplateController.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Home Guardian - Admin 执行器能力模板控制器
+ *
+ * 管理可复用的整设备控制能力模板（空调/调光灯/开关）。
+ * controls 字段以 JSON 文本编辑（v1 简版，可视化编辑器留后续）。
+ */
+
+namespace app\controller\admin;
+
+use app\model\CapabilityTemplate;
+use support\Request;
+
+class CapabilityTemplateController
+{
+    public function index(Request $request)
+    {
+        $templates = CapabilityTemplate::orderBy('id')->get();
+        $templateList = $templates->map(function ($t) {
+            $arr = $t->toArray();
+            $arr['control_count'] = is_array($t->controls) ? count($t->controls) : 0;
+            return $arr;
+        })->toArray();
+
+        return view('admin/capability-template/list', [
+            'templateList' => $templateList,
+            'nav'          => 'capability-templates',
+            'adminUser'    => $request->adminUser,
+        ]);
+    }
+
+    public function create(Request $request)
+    {
+        return view('admin/capability-template/form', [
+            'template'  => null,
+            'nav'       => 'capability-templates',
+            'adminUser' => $request->adminUser,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->post();
+
+        if ($err = $this->validateData($data)) {
+            return view('admin/capability-template/form', [
+                'template'  => null,
+                'error'     => $err,
+                'old'       => $data,
+                'nav'       => 'capability-templates',
+                'adminUser' => $request->adminUser,
+            ]);
+        }
+
+        CapabilityTemplate::create([
+            'name'            => $data['name'],
+            'device_category' => $data['device_category'] ?? null,
+            'control_mode'    => $data['control_mode'] ?? 'discrete',
+            'controls'        => json_decode($data['controls'] ?? '[]', true) ?: [],
+            'description'     => $data['description'] ?? null,
+        ]);
+
+        return redirect('/admin/capability-templates');
+    }
+
+    public function edit(Request $request, int $id)
+    {
+        $template = CapabilityTemplate::find($id);
+        if (!$template) {
+            return redirect('/admin/capability-templates');
+        }
+
+        return view('admin/capability-template/form', [
+            'template'  => $template,
+            'nav'       => 'capability-templates',
+            'adminUser' => $request->adminUser,
+        ]);
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $template = CapabilityTemplate::find($id);
+        if (!$template) {
+            return redirect('/admin/capability-templates');
+        }
+
+        $data = $request->post();
+        if ($err = $this->validateData($data)) {
+            return view('admin/capability-template/form', [
+                'template'  => $template,
+                'error'     => $err,
+                'old'       => $data,
+                'nav'       => 'capability-templates',
+                'adminUser' => $request->adminUser,
+            ]);
+        }
+
+        $template->update([
+            'name'            => $data['name'],
+            'device_category' => $data['device_category'] ?? null,
+            'control_mode'    => $data['control_mode'] ?? 'discrete',
+            'controls'        => json_decode($data['controls'] ?? '[]', true) ?: [],
+            'description'     => $data['description'] ?? null,
+        ]);
+
+        return redirect('/admin/capability-templates');
+    }
+
+    public function delete(Request $request, int $id)
+    {
+        $template = CapabilityTemplate::find($id);
+        if ($template) {
+            $template->delete();
+        }
+        return redirect('/admin/capability-templates');
+    }
+
+    /**
+     * 校验表单数据，返回错误信息（无错误返回 null）
+     */
+    private function validateData(array $data): ?string
+    {
+        if (empty($data['name'])) {
+            return 'name 不能为空';
+        }
+        if (!in_array($data['control_mode'] ?? '', ['discrete', 'merge'], true)) {
+            return 'control_mode 必须是 discrete 或 merge';
+        }
+        $controls = json_decode($data['controls'] ?? '[]', true);
+        if (json_last_error() !== JSON_ERROR_NONE || !is_array($controls)) {
+            return 'controls 必须是合法的 JSON 数组';
+        }
+        return null;
+    }
+}

--- a/app/controller/admin/DeviceController.php
+++ b/app/controller/admin/DeviceController.php
@@ -7,6 +7,7 @@ namespace app\controller\admin;
 
 use app\model\Device;
 use app\model\MetricDefinition;
+use app\model\CapabilityTemplate;
 use app\service\DeviceService;
 use support\Request;
 
@@ -71,11 +72,13 @@ class DeviceController
     {
         $metricDefinitions = MetricDefinition::ordered()->get(['id', 'metric_key', 'label', 'unit', 'icon'])->toArray();
         $gateways = Device::where('type', 'gateway')->orderBy('name')->get(['id', 'device_uid', 'name'])->toArray();
+        $capabilityTemplates = CapabilityTemplate::orderBy('name')->get(['id', 'name', 'control_mode', 'controls', 'device_category'])->toArray();
 
         return view('admin/device/form', [
             'device'            => null,
             'metricDefinitions' => $metricDefinitions,
             'gateways'          => $gateways,
+            'capabilityTemplates' => $capabilityTemplates,
             'nav'               => 'devices',
             'adminUser'         => $request->adminUser,
         ]);
@@ -88,6 +91,7 @@ class DeviceController
         if (empty($data['device_uid']) || empty($data['name']) || empty($data['type'])) {
             $metricDefinitions = MetricDefinition::ordered()->get(['id', 'metric_key', 'label', 'unit', 'icon'])->toArray();
             $gateways = Device::where('type', 'gateway')->orderBy('name')->get(['id', 'device_uid', 'name'])->toArray();
+        $capabilityTemplates = CapabilityTemplate::orderBy('name')->get(['id', 'name', 'control_mode', 'controls', 'device_category'])->toArray();
             return view('admin/device/form', [
                 'device'            => null,
                 'metricDefinitions' => $metricDefinitions,
@@ -112,11 +116,13 @@ class DeviceController
 
         $metricDefinitions = MetricDefinition::ordered()->get(['id', 'metric_key', 'label', 'unit', 'icon'])->toArray();
         $gateways = Device::where('type', 'gateway')->orderBy('name')->get(['id', 'device_uid', 'name'])->toArray();
+        $capabilityTemplates = CapabilityTemplate::orderBy('name')->get(['id', 'name', 'control_mode', 'controls', 'device_category'])->toArray();
 
         return view('admin/device/form', [
             'device'            => $device,
             'metricDefinitions' => $metricDefinitions,
             'gateways'          => $gateways,
+            'capabilityTemplates' => $capabilityTemplates,
             'nav'               => 'devices',
             'adminUser'         => $request->adminUser,
         ]);

--- a/app/model/CapabilityTemplate.php
+++ b/app/model/CapabilityTemplate.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Home Guardian - 执行器能力模板模型
+ *
+ * 对应 capability_templates 表，存储可复用的整设备控制能力模板（空调/调光灯/开关）。
+ * 新建/编辑设备时从模板填充到 devices.capability。
+ *
+ * controls 是控制点数组，每个控制点描述一个 UI 控件及其映射的指令，结构见迁移文件与
+ * ActuatorService 的校验逻辑。control_mode 决定下发方式：
+ *   - discrete: 每个控制点发自己的 action
+ *   - merge:    所有控制点共同维护一份状态，每次发完整状态（action 固定为 set_state）
+ */
+
+namespace app\model;
+
+use support\Model;
+
+class CapabilityTemplate extends Model
+{
+    protected $table = 'capability_templates';
+
+    protected $fillable = [
+        'name',
+        'device_category',
+        'control_mode',
+        'controls',
+        'description',
+    ];
+
+    protected $casts = [
+        'controls'   => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    const MODE_DISCRETE = 'discrete';
+    const MODE_MERGE    = 'merge';
+
+    /**
+     * 合法控件类型
+     */
+    const VALID_WIDGETS = ['switch', 'stepper', 'slider', 'enum', 'button', 'number', 'text'];
+
+    /**
+     * 合法值类型
+     */
+    const VALID_VALUE_TYPES = ['bool', 'int', 'float', 'string', 'enum'];
+}

--- a/app/model/Device.php
+++ b/app/model/Device.php
@@ -43,6 +43,7 @@ class Device extends Model
         'is_online',
         'metric_fields',
         'gateway_uid',
+        'capability',
     ];
 
     /**
@@ -63,6 +64,7 @@ class Device extends Model
         'created_at'    => 'datetime',
         'updated_at'    => 'datetime',
         'metric_fields' => 'array',
+        'capability'    => 'array',
     ];
 
     /* ============================
@@ -75,6 +77,14 @@ class Device extends Model
     public function attributes(): HasMany
     {
         return $this->hasMany(DeviceAttribute::class, 'device_id');
+    }
+
+    /**
+     * 执行器的当前/期望状态（一对一）
+     */
+    public function state()
+    {
+        return $this->hasOne(DeviceState::class, 'device_id');
     }
 
     /**

--- a/app/model/DeviceState.php
+++ b/app/model/DeviceState.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Home Guardian - 设备状态模型
+ *
+ * 对应 device_states 表，存储执行器的当前/期望状态（JSONB）。
+ * 与 Redis 缓存（hg:device:state:{id}）双写：Redis 提供热读取，本表负责持久化与重启恢复。
+ *
+ * 状态来源：
+ *   - 闭环设备：通过 state/post 上报真实状态（reported_at 记录上报时间）
+ *   - 开环设备（如红外）：下发指令时更新为"期望状态"（虚拟状态）
+ */
+
+namespace app\model;
+
+use support\Model;
+
+class DeviceState extends Model
+{
+    protected $table = 'device_states';
+
+    protected $primaryKey = 'device_id';
+    public $incrementing = false;
+
+    // 只有 updated_at，没有 created_at
+    const CREATED_AT = null;
+
+    protected $fillable = [
+        'device_id',
+        'state',
+        'reported_at',
+        'updated_at',
+    ];
+
+    protected $casts = [
+        'state'       => 'array',
+        'reported_at' => 'datetime',
+        'updated_at'  => 'datetime',
+    ];
+
+    /**
+     * 所属设备
+     */
+    public function device()
+    {
+        return $this->belongsTo(Device::class, 'device_id');
+    }
+}

--- a/app/process/MqttSubscriber.php
+++ b/app/process/MqttSubscriber.php
@@ -326,6 +326,22 @@ class MqttSubscriber
 
             $this->redisPub->publish('ws:broadcast', $wsMessage);
 
+            // 执行器状态上报：state/post 带 state 字段时，落库并推送（闭环设备的真实状态）
+            if (isset($data['state']) && is_array($data['state'])) {
+                try {
+                    \app\service\ActuatorService::saveState($device->id, $data['state'], true);
+                    $this->redisPub->publish('ws:broadcast', json_encode([
+                        'type'            => 'device_state',
+                        'device_id'       => $device->id,
+                        'device_uid'      => $deviceUid,
+                        'device_location' => $device->location,
+                        'state'           => $data['state'],
+                    ], JSON_UNESCAPED_UNICODE));
+                } catch (\Throwable $e) {
+                    \support\Log::error("保存设备状态失败: {$e->getMessage()}");
+                }
+            }
+
             // 网关离线时，批量将其下所有传感器也标记为离线
             if (!$isOnline && $device->type === 'gateway') {
                 $sensors = Device::where('gateway_uid', $deviceUid)->get(['id', 'device_uid', 'location']);

--- a/app/service/ActuatorService.php
+++ b/app/service/ActuatorService.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Home Guardian - 执行器控制服务
+ *
+ * 执行器控制的统一入口（API 与自动化共用）。负责：
+ *   1. 按设备 capability 校验 action 与 params 合法性
+ *   2. discrete 模式：单控制点直发；merge 模式：合并完整状态后下发（action=set_state）
+ *   3. 设备状态双写：Redis（hg:device:state:{id}）+ device_states 表
+ *   4. 通过 WS 推送状态变更，多端同步
+ *
+ * 状态语义：
+ *   - 闭环设备由 state/post 上报真实状态（见 MqttSubscriber，reported=true）
+ *   - 开环设备（红外）下发即更新"期望状态"（reported=false），作为前端展示依据
+ */
+
+namespace app\service;
+
+use app\model\Device;
+use app\model\DeviceState;
+use app\model\CapabilityTemplate;
+use app\exception\BusinessException;
+use support\Redis;
+use support\Log;
+
+class ActuatorService
+{
+    /**
+     * 状态缓存键前缀（default 连接，DB0，带 hg: 前缀 → hg:device:state:{id}）
+     */
+    private const STATE_CACHE_KEY = 'device:state:';
+
+    /**
+     * 状态缓存有效期（秒）
+     */
+    private const STATE_TTL = 86400;
+
+    /**
+     * 处理一条控制指令
+     *
+     * @param  Device $device 目标设备
+     * @param  string $action 指令动作
+     * @param  array  $params 指令参数
+     * @return \app\model\CommandLog
+     *
+     * @throws BusinessException 设备无控制能力或参数校验失败
+     */
+    public static function applyCommand(Device $device, string $action, array $params): \app\model\CommandLog
+    {
+        $cap = $device->capability;
+        if (empty($cap) || empty($cap['controls']) || !is_array($cap['controls'])) {
+            throw new BusinessException('该设备未配置控制能力', 422, 2100);
+        }
+
+        // 1. 校验 action + params
+        self::validate($cap, $action, $params);
+
+        $mode = $cap['control_mode'] ?? CapabilityTemplate::MODE_DISCRETE;
+
+        if ($mode === CapabilityTemplate::MODE_MERGE) {
+            // 2a. merge：读期望状态 → 合并改动 → 下发完整状态
+            $current = self::getState($device->id) ?: self::defaultState($cap);
+            $next = array_merge($current, $params);
+
+            self::saveState($device->id, $next, false);
+            $log = MqttCommandService::sendCommand($device->id, ['action' => $action, 'params' => $next]);
+            self::pushStateWs($device, $next);
+            return $log;
+        }
+
+        // 2b. discrete：单点直发，乐观更新对应 state_key
+        $log = MqttCommandService::sendCommand($device->id, ['action' => $action, 'params' => $params]);
+
+        $patch = self::statePatchFor($cap, $action, $params);
+        if (!empty($patch)) {
+            $next = array_merge(self::getState($device->id) ?: [], $patch);
+            self::saveState($device->id, $next, false);
+            self::pushStateWs($device, $next);
+        }
+        return $log;
+    }
+
+    /* ============================
+     * 校验
+     * ============================ */
+
+    /**
+     * 校验 action 是否被声明，且每个 param 命中控制点并符合类型/范围/枚举
+     *
+     * @throws BusinessException
+     */
+    private static function validate(array $cap, string $action, array $params): void
+    {
+        // action => [param => controlPoint]
+        $commands = [];
+        foreach ($cap['controls'] as $c) {
+            if (!isset($c['command'], $c['param'])) {
+                continue;
+            }
+            $commands[$c['command']][$c['param']] = $c;
+        }
+
+        if (!isset($commands[$action])) {
+            throw new BusinessException("不支持的指令: {$action}", 422, 2101);
+        }
+
+        foreach ($params as $key => $value) {
+            $cp = $commands[$action][$key] ?? null;
+            if (!$cp) {
+                throw new BusinessException("非法参数: {$key}", 422, 2102);
+            }
+            self::validateValue($cp, $value);
+        }
+    }
+
+    /**
+     * 按控制点定义校验单个值
+     *
+     * @throws BusinessException
+     */
+    private static function validateValue(array $cp, mixed $value): void
+    {
+        $label = $cp['label'] ?? $cp['key'] ?? $cp['param'] ?? '参数';
+        $type = $cp['value_type'] ?? 'string';
+
+        switch ($type) {
+            case 'bool':
+                if (!is_bool($value)) {
+                    throw new BusinessException("{$label} 必须为布尔值", 422, 2103);
+                }
+                break;
+
+            case 'int':
+            case 'float':
+                if (!is_numeric($value)) {
+                    throw new BusinessException("{$label} 必须为数值", 422, 2103);
+                }
+                $num = $value + 0;
+                if (isset($cp['min']) && $num < $cp['min']) {
+                    throw new BusinessException("{$label} 不能小于 {$cp['min']}", 422, 2104);
+                }
+                if (isset($cp['max']) && $num > $cp['max']) {
+                    throw new BusinessException("{$label} 不能大于 {$cp['max']}", 422, 2104);
+                }
+                break;
+
+            case 'enum':
+                $allowed = array_map(fn($o) => $o['value'] ?? null, $cp['options'] ?? []);
+                if (!in_array($value, $allowed, true)) {
+                    throw new BusinessException("{$label} 取值非法", 422, 2105);
+                }
+                break;
+
+            case 'string':
+            default:
+                if (!is_string($value) && !is_numeric($value)) {
+                    throw new BusinessException("{$label} 必须为字符串", 422, 2103);
+                }
+                break;
+        }
+    }
+
+    /**
+     * discrete 模式：根据 action+params 推导出要更新的状态片段 {state_key: value}
+     */
+    private static function statePatchFor(array $cap, string $action, array $params): array
+    {
+        $patch = [];
+        foreach ($cap['controls'] as $c) {
+            if (($c['command'] ?? null) !== $action) {
+                continue;
+            }
+            $param = $c['param'] ?? null;
+            $stateKey = $c['state_key'] ?? $param;
+            if ($param !== null && array_key_exists($param, $params)) {
+                $patch[$stateKey] = $params[$param];
+            }
+        }
+        return $patch;
+    }
+
+    /**
+     * 用各控制点的 default 拼出初始状态
+     */
+    private static function defaultState(array $cap): array
+    {
+        $state = [];
+        foreach ($cap['controls'] as $c) {
+            $key = $c['state_key'] ?? $c['param'] ?? null;
+            if ($key !== null && array_key_exists('default', $c)) {
+                $state[$key] = $c['default'];
+            }
+        }
+        return $state;
+    }
+
+    /* ============================
+     * 状态读写（Redis + DB 双写）
+     * ============================ */
+
+    /**
+     * 读取设备当前状态（优先 Redis，回退 DB）
+     *
+     * @return array|null
+     */
+    public static function getState(int $deviceId): ?array
+    {
+        try {
+            $raw = Redis::connection('default')->get(self::STATE_CACHE_KEY . $deviceId);
+            if ($raw) {
+                return json_decode($raw, true);
+            }
+        } catch (\Throwable $e) {
+            Log::error("读取设备状态缓存失败: {$e->getMessage()}");
+        }
+
+        $row = DeviceState::find($deviceId);
+        return $row?->state;
+    }
+
+    /**
+     * 写入设备状态（Redis + DB 双写）
+     *
+     * @param int   $deviceId 设备 ID
+     * @param array $state    完整状态
+     * @param bool  $reported true=设备真实上报，false=指令产生的期望状态
+     */
+    public static function saveState(int $deviceId, array $state, bool $reported): void
+    {
+        try {
+            Redis::connection('default')->setex(
+                self::STATE_CACHE_KEY . $deviceId,
+                self::STATE_TTL,
+                json_encode($state, JSON_UNESCAPED_UNICODE)
+            );
+        } catch (\Throwable $e) {
+            Log::error("写入设备状态缓存失败: {$e->getMessage()}");
+        }
+
+        $attrs = ['state' => $state, 'updated_at' => now()];
+        if ($reported) {
+            $attrs['reported_at'] = now();
+        }
+
+        DeviceState::updateOrCreate(['device_id' => $deviceId], $attrs);
+    }
+
+    /**
+     * 推送状态变更到 WebSocket
+     */
+    private static function pushStateWs(Device $device, array $state): void
+    {
+        try {
+            Redis::connection('pubsub')->publish('ws:broadcast', json_encode([
+                'type'            => 'device_state',
+                'device_id'       => $device->id,
+                'device_uid'      => $device->device_uid,
+                'device_location' => $device->location,
+                'state'           => $state,
+            ], JSON_UNESCAPED_UNICODE));
+        } catch (\Throwable $e) {
+            Log::error("设备状态 WS 推送失败: {$e->getMessage()}");
+        }
+    }
+}

--- a/app/service/DeviceService.php
+++ b/app/service/DeviceService.php
@@ -45,6 +45,11 @@ class DeviceService
             $data['metric_fields'] = json_decode($data['metric_fields'], true);
         }
 
+        // capability JSON 字符串转数组（执行器控制能力）
+        if (isset($data['capability']) && is_string($data['capability'])) {
+            $data['capability'] = $data['capability'] === '' ? null : json_decode($data['capability'], true);
+        }
+
         return Device::create($data);
     }
 
@@ -73,6 +78,11 @@ class DeviceService
         // metric_fields JSON 字符串转数组
         if (isset($data['metric_fields']) && is_string($data['metric_fields'])) {
             $data['metric_fields'] = json_decode($data['metric_fields'], true);
+        }
+
+        // capability JSON 字符串转数组（执行器控制能力）
+        if (isset($data['capability']) && is_string($data['capability'])) {
+            $data['capability'] = $data['capability'] === '' ? null : json_decode($data['capability'], true);
         }
 
         $device->update($data);

--- a/app/view/admin/capability-template/form.html
+++ b/app/view/admin/capability-template/form.html
@@ -1,0 +1,68 @@
+{extend name="admin/layout" /}
+{block name="content"}
+<div class="layui-card">
+    <div class="layui-card-header">{{$template ? '编辑能力模板' : '添加能力模板'}}</div>
+    <div class="layui-card-body" style="padding: 20px;">
+        {if !empty($error)}
+        <div class="layui-bg-red" style="padding:10px;margin-bottom:15px;border-radius:4px;">{{$error}}</div>
+        {/if}
+
+        {php}
+        // 计算 controls 的 JSON 文本：优先回显用户上次输入（old），否则用模板已有值
+        if (isset($old['controls'])) {
+            $controlsJson = $old['controls'];
+        } elseif ($template) {
+            $controlsJson = json_encode($template['controls'], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+        } else {
+            $controlsJson = "[]";
+        }
+        $currentMode = $template['control_mode'] ?? ($old['control_mode'] ?? 'discrete');
+        {/php}
+
+        <form class="layui-form" method="post" action="{{$template ? '/admin/capability-templates/'.$template['id'].'/update' : '/admin/capability-templates/store'}}">
+            <div class="layui-form-item">
+                <label class="layui-form-label">名称</label>
+                <div class="layui-input-block">
+                    <input type="text" name="name" value="{{$template['name'] ?? ($old['name'] ?? '')}}" required lay-verify="required" class="layui-input" placeholder="如 空调、调光灯">
+                </div>
+            </div>
+            <div class="layui-form-item">
+                <label class="layui-form-label">归类</label>
+                <div class="layui-input-block">
+                    <input type="text" name="device_category" value="{{$template['device_category'] ?? ($old['device_category'] ?? '')}}" class="layui-input" placeholder="如 ac / light / switch / curtain（用于图标）">
+                </div>
+            </div>
+            <div class="layui-form-item">
+                <label class="layui-form-label">下发模式</label>
+                <div class="layui-input-block">
+                    <select name="control_mode" lay-verify="required">
+                        <option value="discrete" {{$currentMode === 'discrete' ? 'selected' : ''}}>discrete（每个控制点发独立指令，适合开关/灯）</option>
+                        <option value="merge" {{$currentMode === 'merge' ? 'selected' : ''}}>merge（合并完整状态发 set_state，适合红外空调）</option>
+                    </select>
+                </div>
+            </div>
+            <div class="layui-form-item">
+                <label class="layui-form-label">描述</label>
+                <div class="layui-input-block">
+                    <input type="text" name="description" value="{{$template['description'] ?? ($old['description'] ?? '')}}" class="layui-input" placeholder="模板描述（可选）">
+                </div>
+            </div>
+            <div class="layui-form-item">
+                <label class="layui-form-label">控制点 (controls)</label>
+                <div class="layui-input-block">
+                    <textarea name="controls" class="layui-textarea" style="min-height:280px;font-family:monospace;font-size:13px;" placeholder='[{"key":"power","label":"电源","widget":"switch","value_type":"bool","command":"set_power","param":"on","state_key":"power","default":false}]'>{{$controlsJson}}</textarea>
+                    <div class="layui-form-mid layui-word-aux" style="margin-top:6px;">
+                        JSON 数组，每个控制点字段：key/label/widget(switch|stepper|slider|enum|button)/value_type(bool|int|float|string|enum)/command/param/state_key/min/max/step/unit/options/default/depends_on/order
+                    </div>
+                </div>
+            </div>
+            <div class="layui-form-item">
+                <div class="layui-input-block">
+                    <button class="layui-btn" lay-submit>保存</button>
+                    <a href="/admin/capability-templates" class="layui-btn layui-btn-primary">取消</a>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+{/block}

--- a/app/view/admin/capability-template/list.html
+++ b/app/view/admin/capability-template/list.html
@@ -1,0 +1,46 @@
+{extend name="admin/layout" /}
+{block name="content"}
+<div class="layui-card">
+    <div class="layui-card-header">
+        执行器能力模板
+        <a href="/admin/capability-templates/create" class="layui-btn layui-btn-sm layui-btn-normal" style="float:right;margin-top:3px;">
+            <i class="layui-icon layui-icon-add-1"></i> 添加模板
+        </a>
+    </div>
+    <div class="layui-card-body">
+        <table class="layui-table" lay-skin="line">
+            <colgroup><col width="60"><col width="150"><col width="100"><col width="100"><col width="90"><col><col width="150"></colgroup>
+            <thead>
+                <tr><th>ID</th><th>名称</th><th>归类</th><th>下发模式</th><th>控制点数</th><th>描述</th><th>操作</th></tr>
+            </thead>
+            <tbody>
+                {volist name="templateList" id="t"}
+                <tr>
+                    <td>{{$t['id']}}</td>
+                    <td>{{$t['name']}}</td>
+                    <td><code>{{$t['device_category'] ?: '-'}}</code></td>
+                    <td>
+                        {if $t['control_mode'] === 'merge'}
+                        <span class="layui-badge layui-bg-blue">merge</span>
+                        {else}
+                        <span class="layui-badge layui-bg-green">discrete</span>
+                        {/if}
+                    </td>
+                    <td>{{$t['control_count']}}</td>
+                    <td>{{$t['description'] ?: '-'}}</td>
+                    <td>
+                        <a href="/admin/capability-templates/{{$t['id']}}/edit" class="layui-btn layui-btn-xs">编辑</a>
+                        <form method="post" action="/admin/capability-templates/{{$t['id']}}/delete" style="display:inline;" onsubmit="return confirm('确定删除？')">
+                            <button type="submit" class="layui-btn layui-btn-xs layui-btn-danger">删除</button>
+                        </form>
+                    </td>
+                </tr>
+                {/volist}
+                {empty name="templateList"}
+                <tr><td colspan="7" style="text-align:center;color:#999;">暂无能力模板</td></tr>
+                {/empty}
+            </tbody>
+        </table>
+    </div>
+</div>
+{/block}

--- a/app/view/admin/device/form.html
+++ b/app/view/admin/device/form.html
@@ -78,6 +78,33 @@
                     <div class="layui-form-mid layui-word-aux">不配置则使用全局指标定义</div>
                 </div>
             </div>
+            <!-- 控制能力配置（仅执行器） -->
+            <div class="layui-form-item" id="capability-field" style="display:none;">
+                <label class="layui-form-label">控制能力</label>
+                <div class="layui-input-block">
+                    <input type="hidden" name="capability" id="capability_input" value="">
+                    <div style="margin-bottom:10px;">
+                        <select id="cap_template_select" lay-ignore style="display:inline-block;width:220px;height:38px;border:1px solid #e6e6e6;border-radius:2px;padding:0 10px;">
+                            <option value="">从能力模板填充...</option>
+                            {volist name="capabilityTemplates" id="ct"}
+                            <option value="{{:htmlentities(json_encode($ct, JSON_UNESCAPED_UNICODE))}}">{{$ct['name']}} ({{$ct['control_mode']}})</option>
+                            {/volist}
+                        </select>
+                        <button type="button" class="layui-btn layui-btn-sm" onclick="applyCapTemplate()">填充</button>
+                    </div>
+                    <div style="margin-bottom:8px;">
+                        下发模式：
+                        <select id="cap_mode" lay-ignore style="width:160px;height:36px;border:1px solid #e6e6e6;border-radius:2px;padding:0 8px;" onchange="syncCapability()">
+                            <option value="discrete">discrete（独立指令）</option>
+                            <option value="merge">merge（全量 set_state）</option>
+                        </select>
+                    </div>
+                    <textarea id="cap_controls" class="layui-textarea" style="min-height:220px;font-family:monospace;font-size:13px;" oninput="syncCapability()" placeholder='[{"key":"power","label":"电源","widget":"switch","value_type":"bool","command":"set_power","param":"on","state_key":"power","default":false}]'></textarea>
+                    <div class="layui-form-mid layui-word-aux" style="margin-top:6px;">
+                        控制点 JSON 数组。可先选模板填充再微调。留空表示该执行器暂无控制界面。
+                    </div>
+                </div>
+            </div>
             {if !$device}
             <div class="layui-form-item">
                 <label class="layui-form-label">MQTT 密码</label>
@@ -188,12 +215,65 @@ function toggleGatewayField() {
         gwField.style.display = (typeSelect.value === 'gateway') ? 'none' : '';
     }
 }
+
+// ===== 控制能力（执行器） =====
+// 初始化已有 capability
+{php}
+    $cap = $device['capability'] ?? ($old['capability'] ?? null);
+    if (is_string($cap)) $cap = json_decode($cap, true);
+    if (!is_array($cap)) $cap = null;
+{/php}
+{if $cap !== null}
+(function(){
+    var cap = {php}echo json_encode($cap, JSON_UNESCAPED_UNICODE);{/php};
+    if (cap.control_mode) document.getElementById('cap_mode').value = cap.control_mode;
+    document.getElementById('cap_controls').value = JSON.stringify(cap.controls || [], null, 2);
+})();
+{/if}
+
+// 把 mode + controls 文本组合进隐藏字段 capability
+function syncCapability() {
+    var typeSelect = document.querySelector('select[name="type"]');
+    var input = document.getElementById('capability_input');
+    if (!typeSelect || typeSelect.value !== 'actuator') { input.value = ''; return; }
+    var raw = document.getElementById('cap_controls').value.trim();
+    if (!raw) { input.value = ''; return; }
+    try {
+        var controls = JSON.parse(raw);
+        input.value = JSON.stringify({ control_mode: document.getElementById('cap_mode').value, controls: controls });
+    } catch (e) {
+        // JSON 非法时不阻断，但提交的 capability 留空，避免存坏数据
+        input.value = '';
+    }
+}
+
+// 选模板填充
+function applyCapTemplate() {
+    var sel = document.getElementById('cap_template_select');
+    if (!sel.value) return;
+    var tpl = JSON.parse(sel.value);
+    document.getElementById('cap_mode').value = tpl.control_mode || 'discrete';
+    document.getElementById('cap_controls').value = JSON.stringify(tpl.controls || [], null, 2);
+    syncCapability();
+}
+
+// 根据类型显示/隐藏控制能力区块
+function toggleCapabilityField() {
+    var typeSelect = document.querySelector('select[name="type"]');
+    var capField = document.getElementById('capability-field');
+    if (typeSelect && capField) {
+        capField.style.display = (typeSelect.value === 'actuator') ? '' : 'none';
+    }
+    syncCapability();
+}
+
 // 初始化
 toggleGatewayField();
+toggleCapabilityField();
 // 监听类型变化（LayUI select 需要用 form.on）
 layui.use('form', function(){
     layui.form.on('select()', function(data){
-        if (data.elem.name === 'type') toggleGatewayField();
+        if (data.elem.name === 'type') { toggleGatewayField(); toggleCapabilityField(); }
     });
 });
 </script>

--- a/app/view/admin/layout.html
+++ b/app/view/admin/layout.html
@@ -49,11 +49,12 @@
                 <li class="layui-nav-item {{$nav === 'dashboard' ? 'layui-this' : ''}}">
                     <a href="/admin/dashboard"><i class="layui-icon layui-icon-home"></i> 仪表盘</a>
                 </li>
-                <li class="layui-nav-item {{in_array($nav, ['devices','telemetry','metric-definitions']) ? 'layui-nav-itemed' : ''}}">
+                <li class="layui-nav-item {{in_array($nav, ['devices','telemetry','metric-definitions','capability-templates']) ? 'layui-nav-itemed' : ''}}">
                     <a href="javascript:;"><i class="layui-icon layui-icon-wifi"></i> 设备管理</a>
                     <dl class="layui-nav-child">
                         <dd class="{{$nav === 'devices' ? 'layui-this' : ''}}"><a href="/admin/devices">设备列表</a></dd>
                         <dd class="{{$nav === 'metric-definitions' ? 'layui-this' : ''}}"><a href="/admin/metric-definitions">指标定义</a></dd>
+                        <dd class="{{$nav === 'capability-templates' ? 'layui-this' : ''}}"><a href="/admin/capability-templates">能力模板</a></dd>
                         <dd class="{{$nav === 'telemetry' ? 'layui-this' : ''}}"><a href="/admin/telemetry">遥测数据</a></dd>
                     </dl>
                 </li>

--- a/config/route.php
+++ b/config/route.php
@@ -114,6 +114,14 @@ Route::group('/admin', function () {
     Route::post('/locations/store', [app\controller\admin\LocationController::class, 'store']);
     Route::post('/locations/{id:\d+}/delete', [app\controller\admin\LocationController::class, 'delete']);
 
+    // 执行器能力模板
+    Route::get('/capability-templates', [app\controller\admin\CapabilityTemplateController::class, 'index']);
+    Route::get('/capability-templates/create', [app\controller\admin\CapabilityTemplateController::class, 'create']);
+    Route::post('/capability-templates/store', [app\controller\admin\CapabilityTemplateController::class, 'store']);
+    Route::get('/capability-templates/{id:\d+}/edit', [app\controller\admin\CapabilityTemplateController::class, 'edit']);
+    Route::post('/capability-templates/{id:\d+}/update', [app\controller\admin\CapabilityTemplateController::class, 'update']);
+    Route::post('/capability-templates/{id:\d+}/delete', [app\controller\admin\CapabilityTemplateController::class, 'delete']);
+
 })->middleware([AdminAuthMiddleware::class]);
 
 /*

--- a/database/php-migrations/2026_06_18_000001_create_capability_templates_table.php
+++ b/database/php-migrations/2026_06_18_000001_create_capability_templates_table.php
@@ -1,0 +1,99 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Eloquent\Migrations\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->schema()->create('capability_templates', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100)->comment('模板名，如 空调/调光灯/开关');
+            $table->string('device_category', 50)->nullable()->comment('归类: switch/light/ac/curtain，用于图标');
+            $table->string('control_mode', 20)->default('discrete')->comment('merge | discrete');
+            $table->jsonb('controls')->default('[]')->comment('控制点数组');
+            $table->text('description')->nullable();
+            $table->timestampsTz();
+        });
+
+        // 自动更新 updated_at 触发器
+        $this->db()->unprepared("
+            CREATE TRIGGER trg_capability_templates_updated_at
+                BEFORE UPDATE ON capability_templates
+                FOR EACH ROW
+                EXECUTE FUNCTION update_updated_at();
+        ");
+
+        // 预置 3 个起步模板
+        $now = now();
+        $rows = [
+            [
+                'name' => '开关', 'device_category' => 'switch', 'control_mode' => 'discrete',
+                'description' => '单路开关/插座',
+                'controls' => [
+                    ['key' => 'power', 'label' => '电源', 'widget' => 'switch', 'value_type' => 'bool',
+                     'command' => 'set_power', 'param' => 'on', 'state_key' => 'power', 'default' => false, 'icon' => '🔌', 'order' => 1],
+                ],
+            ],
+            [
+                'name' => '调光灯', 'device_category' => 'light', 'control_mode' => 'discrete',
+                'description' => '可开关 + 调亮度',
+                'controls' => [
+                    ['key' => 'power', 'label' => '电源', 'widget' => 'switch', 'value_type' => 'bool',
+                     'command' => 'set_power', 'param' => 'on', 'state_key' => 'power', 'default' => false, 'icon' => '💡', 'order' => 1],
+                    ['key' => 'brightness', 'label' => '亮度', 'widget' => 'slider', 'value_type' => 'int',
+                     'command' => 'set_brightness', 'param' => 'value', 'state_key' => 'brightness',
+                     'min' => 0, 'max' => 100, 'step' => 1, 'unit' => '%', 'default' => 50,
+                     'depends_on' => ['power' => true], 'order' => 2],
+                ],
+            ],
+            [
+                'name' => '空调', 'device_category' => 'ac', 'control_mode' => 'merge',
+                'description' => '红外/智能空调，全量状态下发',
+                'controls' => [
+                    ['key' => 'power', 'label' => '电源', 'widget' => 'switch', 'value_type' => 'bool',
+                     'command' => 'set_state', 'param' => 'power', 'state_key' => 'power', 'default' => false, 'icon' => '❄️', 'order' => 1],
+                    ['key' => 'mode', 'label' => '模式', 'widget' => 'enum', 'value_type' => 'enum',
+                     'command' => 'set_state', 'param' => 'mode', 'state_key' => 'mode', 'default' => 'cool',
+                     'options' => [
+                         ['label' => '制冷', 'value' => 'cool'], ['label' => '制热', 'value' => 'heat'],
+                         ['label' => '除湿', 'value' => 'dry'], ['label' => '送风', 'value' => 'fan'],
+                     ],
+                     'depends_on' => ['power' => true], 'order' => 2],
+                    ['key' => 'temp', 'label' => '温度', 'widget' => 'stepper', 'value_type' => 'int',
+                     'command' => 'set_state', 'param' => 'temp', 'state_key' => 'temp',
+                     'min' => 16, 'max' => 30, 'step' => 1, 'unit' => '°C', 'default' => 26,
+                     'depends_on' => ['power' => true], 'order' => 3],
+                    ['key' => 'fan', 'label' => '风速', 'widget' => 'enum', 'value_type' => 'enum',
+                     'command' => 'set_state', 'param' => 'fan', 'state_key' => 'fan', 'default' => 'auto',
+                     'options' => [
+                         ['label' => '自动', 'value' => 'auto'], ['label' => '低', 'value' => 'low'],
+                         ['label' => '中', 'value' => 'mid'], ['label' => '高', 'value' => 'high'],
+                     ],
+                     'depends_on' => ['power' => true], 'order' => 4],
+                    ['key' => 'swing', 'label' => '扫风', 'widget' => 'switch', 'value_type' => 'bool',
+                     'command' => 'set_state', 'param' => 'swing', 'state_key' => 'swing', 'default' => false,
+                     'depends_on' => ['power' => true], 'order' => 5],
+                ],
+            ],
+        ];
+
+        foreach ($rows as $r) {
+            $this->db()->table('capability_templates')->insert([
+                'name'            => $r['name'],
+                'device_category' => $r['device_category'],
+                'control_mode'    => $r['control_mode'],
+                'controls'        => json_encode($r['controls'], JSON_UNESCAPED_UNICODE),
+                'description'     => $r['description'],
+                'created_at'      => $now,
+                'updated_at'      => $now,
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        $this->schema()->dropIfExists('capability_templates');
+    }
+};

--- a/database/php-migrations/2026_06_18_000002_add_capability_to_devices.php
+++ b/database/php-migrations/2026_06_18_000002_add_capability_to_devices.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Eloquent\Migrations\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->schema()->table('devices', function (Blueprint $table) {
+            $table->jsonb('capability')->nullable()
+                ->comment('执行器能力 {control_mode, controls:[...]}，NULL=无控制能力');
+        });
+    }
+
+    public function down(): void
+    {
+        $this->schema()->table('devices', function (Blueprint $table) {
+            $table->dropColumn('capability');
+        });
+    }
+};

--- a/database/php-migrations/2026_06_18_000003_create_device_states_table.php
+++ b/database/php-migrations/2026_06_18_000003_create_device_states_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Eloquent\Migrations\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->schema()->create('device_states', function (Blueprint $table) {
+            $table->integer('device_id')->primary();
+            $table->jsonb('state')->default('{}')->comment('当前/期望状态');
+            $table->timestampTz('reported_at')->nullable()->comment('设备最后一次上报状态时间');
+            $table->timestampTz('updated_at')->useCurrent();
+
+            $table->foreign('device_id')->references('id')->on('devices')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        $this->schema()->dropIfExists('device_states');
+    }
+};

--- a/mobile/src/api/device.ts
+++ b/mobile/src/api/device.ts
@@ -1,6 +1,33 @@
 import request from './request';
 import type { MetricField } from '@/utils/metricLookup';
 
+export type ControlWidget = 'switch' | 'stepper' | 'slider' | 'enum' | 'button' | 'number' | 'text';
+
+export interface ControlPoint {
+  key: string;
+  label: string;
+  widget: ControlWidget;
+  value_type: 'bool' | 'int' | 'float' | 'string' | 'enum';
+  command: string;
+  param: string;
+  state_key?: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  unit?: string;
+  options?: { label: string; value: string | number; icon?: string }[];
+  default?: unknown;
+  depends_on?: Record<string, unknown>;
+  group?: string;
+  order?: number;
+  icon?: string;
+}
+
+export interface Capability {
+  control_mode: 'merge' | 'discrete';
+  controls: ControlPoint[];
+}
+
 export interface Device {
   id: number;
   device_uid: string;
@@ -12,6 +39,8 @@ export interface Device {
   last_seen: string | null;
   metric_fields: MetricField[] | null;
   gateway_uid: string | null;
+  capability: Capability | null;
+  state?: Record<string, unknown>;
 }
 
 export interface DeviceAttribute {

--- a/mobile/src/components/control/DynamicControlPanel.tsx
+++ b/mobile/src/components/control/DynamicControlPanel.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Switch, Slider, Stepper, Selector, Button } from 'antd-mobile';
+import type { Capability, ControlPoint } from '@/api/device';
+
+interface Props {
+  capability: Capability;
+  state?: Record<string, unknown>;
+  onCommand: (action: string, params: Record<string, unknown>) => void;
+}
+
+type StateMap = Record<string, unknown>;
+
+/** 控制点的状态键（state_key 优先，回退 param） */
+function stateKeyOf(c: ControlPoint): string {
+  return c.state_key ?? c.param;
+}
+
+/** 用真实状态 + 各控制点 default 拼出初始 desired state */
+function buildInitial(capability: Capability, state?: StateMap): StateMap {
+  const next: StateMap = {};
+  for (const c of capability.controls) {
+    const key = stateKeyOf(c);
+    if (state && key in state) next[key] = state[key];
+    else if ('default' in c) next[key] = c.default;
+  }
+  return next;
+}
+
+/** merge 模式：把 desired state 映射成完整 params {param: value} */
+function toParams(capability: Capability, desired: StateMap): Record<string, unknown> {
+  const params: Record<string, unknown> = {};
+  for (const c of capability.controls) {
+    params[c.param] = desired[stateKeyOf(c)];
+  }
+  return params;
+}
+
+export default function DynamicControlPanel({ capability, state, onCommand }: Props) {
+  const isMerge = capability.control_mode === 'merge';
+  const [desired, setDesired] = useState<StateMap>(() => buildInitial(capability, state));
+
+  // 外部状态（WS 推送 / 重新拉取）变化时同步到本地
+  useEffect(() => {
+    setDesired(buildInitial(capability, state));
+    // 仅在传入状态引用变化时同步
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state]);
+
+  // 简易防抖：连续操作（如滑块、温度连点）合并成一次下发
+  const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const emit = (action: string, params: Record<string, unknown>, key: string) => {
+    if (timers.current[key]) clearTimeout(timers.current[key]);
+    timers.current[key] = setTimeout(() => onCommand(action, params), 300);
+  };
+
+  const controls = useMemo(
+    () => [...capability.controls].sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+    [capability.controls],
+  );
+
+  const handleChange = (c: ControlPoint, value: unknown) => {
+    const next = { ...desired, [stateKeyOf(c)]: value };
+    setDesired(next);
+    if (isMerge) {
+      emit(c.command, toParams(capability, next), 'merge');
+    } else {
+      emit(c.command, { [c.param]: value }, c.key);
+    }
+  };
+
+  /** depends_on：依赖条件不满足时禁用该控件 */
+  const isDisabled = (c: ControlPoint): boolean => {
+    if (!c.depends_on) return false;
+    return Object.entries(c.depends_on).some(([k, v]) => desired[k] !== v);
+  };
+
+  const renderWidget = (c: ControlPoint) => {
+    const disabled = isDisabled(c);
+    const key = stateKeyOf(c);
+    const val = desired[key];
+
+    switch (c.widget) {
+      case 'switch':
+        return (
+          <Switch
+            checked={Boolean(val)}
+            disabled={disabled}
+            onChange={(checked) => handleChange(c, checked)}
+          />
+        );
+
+      case 'slider':
+        return (
+          <div style={{ width: 160 }}>
+            <Slider
+              value={typeof val === 'number' ? val : 0}
+              min={c.min ?? 0}
+              max={c.max ?? 100}
+              step={c.step ?? 1}
+              disabled={disabled}
+              onChange={(v) => handleChange(c, Array.isArray(v) ? v[0] : v)}
+            />
+          </div>
+        );
+
+      case 'stepper':
+        return (
+          <Stepper
+            value={typeof val === 'number' ? val : (c.min ?? 0)}
+            min={c.min}
+            max={c.max}
+            step={c.step ?? 1}
+            disabled={disabled}
+            onChange={(v) => handleChange(c, v)}
+          />
+        );
+
+      case 'enum':
+        return (
+          <Selector
+            options={(c.options ?? []).map((o) => ({ label: o.label, value: o.value }))}
+            value={val !== undefined && val !== null ? [val as string | number] : []}
+            disabled={disabled}
+            onChange={(arr) => { if (arr.length) handleChange(c, arr[0]); }}
+          />
+        );
+
+      case 'button':
+        return (
+          <Button size="small" disabled={disabled} onClick={() => onCommand(c.command, {})}>
+            执行
+          </Button>
+        );
+
+      case 'number':
+      case 'text':
+      default:
+        return (
+          <input
+            className="dyn-control-input"
+            type={c.widget === 'number' ? 'number' : 'text'}
+            defaultValue={val as string | number | undefined}
+            disabled={disabled}
+            onBlur={(e) => handleChange(c, c.widget === 'number' ? Number(e.target.value) : e.target.value)}
+            style={{ width: 120, height: 32, border: '1px solid var(--color-border, #e6e6e6)', borderRadius: 8, padding: '0 8px' }}
+          />
+        );
+    }
+  };
+
+  return (
+    <div className="surface-card detail-section-card" style={{ padding: 16 }}>
+      <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--color-text)', marginBottom: 16 }}>
+        设备控制
+      </div>
+      {controls.map((c) => {
+        const isWide = c.widget === 'enum' || c.widget === 'slider';
+        return (
+          <div
+            key={c.key}
+            style={{
+              display: 'flex',
+              flexDirection: isWide ? 'column' : 'row',
+              alignItems: isWide ? 'stretch' : 'center',
+              justifyContent: 'space-between',
+              gap: isWide ? 8 : 12,
+              marginBottom: 18,
+              opacity: isDisabled(c) ? 0.5 : 1,
+            }}
+          >
+            <span style={{ color: 'var(--color-text)' }}>
+              {c.icon ? `${c.icon} ` : ''}{c.label}
+              {c.unit && typeof desired[stateKeyOf(c)] === 'number' ? `：${desired[stateKeyOf(c)]}${c.unit}` : ''}
+            </span>
+            <div style={{ alignSelf: isWide ? 'stretch' : 'auto' }}>{renderWidget(c)}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/mobile/src/pages/DeviceDetailPage.tsx
+++ b/mobile/src/pages/DeviceDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { NavBar, Switch, Slider, Button, Toast, PullToRefresh } from 'antd-mobile';
+import { NavBar, Button, Toast, PullToRefresh } from 'antd-mobile';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getDevice, sendCommand, getDeviceAttributes, setDeviceAttributes, type Device, type DeviceAttribute } from '@/api/device';
 import { getLatestTelemetry, type LatestMetric } from '@/api/telemetry';
@@ -11,6 +11,7 @@ import StatusTag from '@/components/StatusTag';
 import DeviceIcon from '@/components/DeviceIcon';
 import MetricCard from '@/components/MetricCard';
 import PageLoading from '@/components/PageLoading';
+import DynamicControlPanel from '@/components/control/DynamicControlPanel';
 import { preloadTelemetryRoutes } from '@/router/routeLoaders';
 
 export default function DeviceDetailPage() {
@@ -20,8 +21,7 @@ export default function DeviceDetailPage() {
   const [metrics, setMetrics] = useState<LatestMetric[]>([]);
   const [attributes, setAttributes] = useState<DeviceAttribute[]>([]);
   const [loading, setLoading] = useState(true);
-  const [switchOn, setSwitchOn] = useState(false);
-  const [brightness, setBrightness] = useState(50);
+  const [controlState, setControlState] = useState<Record<string, unknown>>({});
 
   const { definitions, fetchDefinitions } = useMetricDefinitionStore();
 
@@ -35,7 +35,10 @@ export default function DeviceDetailPage() {
         getLatestTelemetry(deviceId),
         getDeviceAttributes(deviceId),
       ]);
-      if (deviceRes.data.code === 0) setDevice(deviceRes.data.data);
+      if (deviceRes.data.code === 0) {
+        setDevice(deviceRes.data.data);
+        if (deviceRes.data.data.state) setControlState(deviceRes.data.data.state);
+      }
       if (telemetryRes.data.code === 0) setMetrics(telemetryRes.data.data);
       if (attrRes.data.code === 0) setAttributes(attrRes.data.data);
     } finally {
@@ -72,6 +75,16 @@ export default function DeviceDetailPage() {
     });
   }, [deviceId]);
   useWSSubscription('telemetry', handleWS);
+
+  // 执行器状态实时同步（其它端操作 / 设备上报）
+  const handleStateWS = useCallback((msg: Record<string, unknown>) => {
+    if ((msg.device_id as number) !== deviceId) return;
+    const st = msg.state as Record<string, unknown> | undefined;
+    if (st && typeof st === 'object') {
+      setControlState((prev) => ({ ...prev, ...st }));
+    }
+  }, [deviceId]);
+  useWSSubscription('device_state', handleStateWS);
 
   const handleCommand = async (action: string, params: Record<string, unknown> = {}) => {
     if (!deviceId) return;
@@ -281,40 +294,16 @@ export default function DeviceDetailPage() {
             </Button>
           </div>
 
-          {device.type === 'actuator' && (
-            <div className="surface-card detail-section-card" style={{ padding: 16 }}>
-              <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--color-text)', marginBottom: 16 }}>
-                设备控制
-              </div>
-              <div style={{ marginBottom: 20, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                <span style={{ color: 'var(--color-text)' }}>电源开关</span>
-                <Switch
-                  checked={switchOn}
-                  onChange={(checked) => {
-                    setSwitchOn(checked);
-                    handleCommand(checked ? 'turn_on' : 'turn_off');
-                  }}
-                />
-              </div>
-              <div style={{ marginBottom: 20 }}>
-                <div style={{ marginBottom: 8, color: 'var(--color-text)' }}>亮度: {brightness}%</div>
-                <Slider
-                  value={brightness}
-                  onChange={(v) => {
-                    const val = Array.isArray(v) ? v[0] : v;
-                    setBrightness(val);
-                    handleCommand('set_brightness', { value: val });
-                  }}
-                />
-              </div>
-              <Button
-                block
-                color="primary"
-                onClick={() => handleCommand('refresh_state')}
-                style={{ borderRadius: 8 }}
-              >
-                刷新状态
-              </Button>
+          {device.type === 'actuator' && device.capability && device.capability.controls?.length > 0 && (
+            <DynamicControlPanel
+              capability={device.capability}
+              state={controlState}
+              onCommand={handleCommand}
+            />
+          )}
+          {device.type === 'actuator' && (!device.capability || !device.capability.controls?.length) && (
+            <div className="surface-card detail-section-card" style={{ padding: 16, color: 'var(--color-text-tertiary)', fontSize: 13, textAlign: 'center' }}>
+              该执行器尚未配置控制能力，请在后台「能力模板 / 设备」中配置。
             </div>
           )}
         </div>


### PR DESCRIPTION
把"执行器能控什么"从写死代码改为声明式 capability schema，前端按 schema
动态渲染控制界面，后端按 schema 校验指令并维护设备状态。

数据层:
- capability_templates 表（可复用整设备模板）+ 内置 开关/调光灯/空调 三模板
- devices.capability JSONB（per-device 控制能力）
- device_states 表（执行器当前/期望状态）

后端:
- ActuatorService: action/params 校验、merge 全量下发(set_state)/discrete 直发、 状态 Redis+device_states 双写、推 WS device_state
- DeviceController: show 返回 capability+state；sendCommand 走 ActuatorService
- MqttSubscriber.handleState: 接收设备上报的执行器状态并落库/推送
- Admin: 能力模板 CRUD + 导航；设备表单按类型显示能力编辑器（选模板填充+JSON）

Mobile:
- DynamicControlPanel: 按 capability 动态渲染 switch/slider/stepper/enum/button， 初值取真实状态(修复刷新归零)、depends_on 联动禁用、merge 防抖全量下发
- DeviceDetailPage: 替换写死的开关+亮度块，订阅 WS device_state 多端同步

固件层按约定暂未实现（平台已备好 {action:set_state, params:{...}} 契约）。