### PR TITLE
feat: 设备自助配网 MVP（后端）

### DIFF
--- a/app/controller/ProvisioningController.php
+++ b/app/controller/ProvisioningController.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Home Guardian - 设备配网控制器
+ *
+ *   POST /api/provisioning/codes              — 生成配对码（需登录 + devices.create）
+ *   GET  /api/provisioning/codes/{code}/status — 轮询配对码状态（需登录）
+ *   POST /api/provisioning/register            — 设备自注册（公开，凭配对码信任）
+ */
+
+namespace app\controller;
+
+use app\service\ProvisioningService;
+use support\Request;
+use OpenApi\Attributes as OA;
+
+#[OA\Tag(name: '设备配网', description: '自助配网：生成配对码、设备自注册')]
+class ProvisioningController
+{
+    #[OA\Post(
+        path: '/provisioning/codes',
+        summary: '生成配对码',
+        description: '移动端"添加设备"时生成一个短时有效的配对码，交给设备完成自注册。',
+        security: [['bearerAuth' => []]],
+        tags: ['设备配网'],
+    )]
+    #[OA\RequestBody(content: new OA\JsonContent(
+        properties: [
+            new OA\Property(property: 'location', type: 'string', example: '客厅', description: '预设设备位置（可选）'),
+        ]
+    ))]
+    #[OA\Response(response: 201, description: '已生成', content: new OA\JsonContent(
+        properties: [
+            new OA\Property(property: 'code', type: 'integer', example: 0),
+            new OA\Property(property: 'data', properties: [
+                new OA\Property(property: 'provision_code', type: 'string', example: 'K7QF9X2M'),
+                new OA\Property(property: 'expires_in', type: 'integer', example: 600),
+                new OA\Property(property: 'expires_at', type: 'string'),
+            ], type: 'object'),
+        ]
+    ))]
+    public function createCode(Request $request)
+    {
+        $location = $request->post('location');
+        $location = (is_string($location) && $location !== '') ? $location : null;
+
+        $record = ProvisioningService::createCode($request->userId(), $location);
+
+        return api_success([
+            'provision_code' => $record->code,
+            'expires_at'     => (string)$record->expires_at,
+            'expires_in'     => max(0, strtotime((string)$record->expires_at) - time()),
+        ], '配对码已生成', 201);
+    }
+
+    #[OA\Get(
+        path: '/provisioning/codes/{code}/status',
+        summary: '查询配对码状态',
+        description: '移动端轮询：pending 等待中 / registered 已注册（含设备信息）/ expired 已过期。',
+        security: [['bearerAuth' => []]],
+        tags: ['设备配网'],
+    )]
+    #[OA\Parameter(name: 'code', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Response(response: 200, description: '成功', content: new OA\JsonContent(
+        properties: [
+            new OA\Property(property: 'code', type: 'integer', example: 0),
+            new OA\Property(property: 'data', properties: [
+                new OA\Property(property: 'status', type: 'string', example: 'registered'),
+                new OA\Property(property: 'device', type: 'object', nullable: true),
+            ], type: 'object'),
+        ]
+    ))]
+    #[OA\Response(response: 404, description: '配对码不存在', content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse'))]
+    public function status(Request $request, string $code)
+    {
+        return api_success(ProvisioningService::statusOf($code, $request->userId()));
+    }
+
+    #[OA\Post(
+        path: '/provisioning/register',
+        summary: '设备自注册',
+        description: '设备连上网后凭配对码注册：平台建网关+子传感器并返回 MQTT 凭证。公开接口，凭配对码信任。',
+        tags: ['设备配网'],
+    )]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(
+        required: ['provision_code', 'gateway'],
+        properties: [
+            new OA\Property(property: 'provision_code', type: 'string', example: 'K7QF9X2M'),
+            new OA\Property(property: 'gateway', type: 'object', properties: [
+                new OA\Property(property: 'device_uid', type: 'string', example: 'esp32-3f2a1b'),
+                new OA\Property(property: 'name', type: 'string', example: '客厅网关'),
+                new OA\Property(property: 'firmware_version', type: 'string', example: '1.0.0'),
+            ]),
+            new OA\Property(property: 'sensors', type: 'array', items: new OA\Items(type: 'object')),
+        ]
+    ))]
+    #[OA\Response(response: 201, description: '注册成功', content: new OA\JsonContent(
+        properties: [
+            new OA\Property(property: 'code', type: 'integer', example: 0),
+            new OA\Property(property: 'data', properties: [
+                new OA\Property(property: 'mqtt', type: 'object', properties: [
+                    new OA\Property(property: 'host', type: 'string'),
+                    new OA\Property(property: 'port', type: 'integer'),
+                    new OA\Property(property: 'username', type: 'string'),
+                    new OA\Property(property: 'password', type: 'string'),
+                ]),
+                new OA\Property(property: 'gateway_uid', type: 'string'),
+                new OA\Property(property: 'devices', type: 'array', items: new OA\Items(type: 'object')),
+            ], type: 'object'),
+        ]
+    ))]
+    #[OA\Response(response: 410, description: '配对码已过期/已用', content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse'))]
+    #[OA\Response(response: 422, description: '配对码无效或缺少字段', content: new OA\JsonContent(ref: '#/components/schemas/ErrorResponse'))]
+    public function register(Request $request)
+    {
+        // 注意：公开接口，安全性依赖配对码（8位高熵 + 10分钟 TTL + 一次性使用）。
+        // 生产建议：① 平台启用 HTTPS（响应含明文 MQTT 密码）；② 对本接口加 IP 限流。
+        $result = ProvisioningService::register($request->post());
+        return api_success($result, '设备已注册', 201);
+    }
+}

--- a/app/model/ProvisionCode.php
+++ b/app/model/ProvisionCode.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Home Guardian - 设备配网配对码模型
+ *
+ * 对应 provision_codes 表。用户在移动端点"添加设备"时生成一个短时有效的配对码，
+ * 交给设备（经 SoftAP 配网页）；设备连上网后凭该码向平台自注册。
+ * 配对码本身即信任凭证：只有登录用户能生成，注册出的设备自动归属该用户 + 位置。
+ */
+
+namespace app\model;
+
+use support\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ProvisionCode extends Model
+{
+    protected $table = 'provision_codes';
+
+    protected $fillable = [
+        'code',
+        'user_id',
+        'location',
+        'status',
+        'device_uid',
+        'expires_at',
+        'used_at',
+    ];
+
+    protected $casts = [
+        'expires_at' => 'datetime',
+        'used_at'    => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    const STATUS_PENDING    = 'pending';
+    const STATUS_REGISTERED = 'registered';
+    const STATUS_EXPIRED    = 'expired';
+
+    /**
+     * 生成该码的用户
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/app/service/ProvisioningService.php
+++ b/app/service/ProvisioningService.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Home Guardian - 设备自助配网服务
+ *
+ * 三个动作：
+ *   1. createCode  — 移动端生成短时配对码（绑定用户 + 位置）
+ *   2. register    — 设备凭配对码自注册：建网关 + 子传感器，返回 MQTT 凭证
+ *   3. statusOf    — 移动端轮询配对码状态，判断设备是否已上线
+ *
+ * 注册出的设备复用现有网关-子设备模型：网关持有 MQTT 凭证，传感器挂在其下（不单独连 MQTT）。
+ */
+
+namespace app\service;
+
+use app\model\ProvisionCode;
+use app\model\Device;
+use app\exception\BusinessException;
+
+class ProvisioningService
+{
+    /** 配对码字符集（去除易混淆的 0/O/1/I） */
+    private const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+    /** 配对码长度 */
+    private const CODE_LENGTH = 8;
+
+    /** 有效期（秒） */
+    private const TTL_SECONDS = 600;
+
+    /**
+     * 生成一个配对码
+     *
+     * @param  int         $userId   生成者
+     * @param  string|null $location 预设位置（可空）
+     * @return ProvisionCode
+     */
+    public static function createCode(int $userId, ?string $location = null): ProvisionCode
+    {
+        return ProvisionCode::create([
+            'code'       => self::generateUniqueCode(),
+            'user_id'    => $userId,
+            'location'   => $location ?: null,
+            'status'     => ProvisionCode::STATUS_PENDING,
+            'expires_at' => date('Y-m-d H:i:s', time() + self::TTL_SECONDS),
+        ]);
+    }
+
+    /**
+     * 生成不重复的配对码
+     *
+     * @throws BusinessException 多次尝试仍冲突
+     */
+    private static function generateUniqueCode(): string
+    {
+        $max = strlen(self::CODE_ALPHABET) - 1;
+        for ($attempt = 0; $attempt < 10; $attempt++) {
+            $code = '';
+            for ($i = 0; $i < self::CODE_LENGTH; $i++) {
+                $code .= self::CODE_ALPHABET[random_int(0, $max)];
+            }
+            if (!ProvisionCode::where('code', $code)->exists()) {
+                return $code;
+            }
+        }
+        throw new BusinessException('配对码生成失败，请重试', 500, 9001);
+    }
+
+    /**
+     * 设备自注册
+     *
+     * @param  array $payload {provision_code, gateway:{device_uid,name,firmware_version,capability?}, sensors:[{...}]}
+     * @return array {mqtt:{host,port,username,password}, gateway_uid, devices:[...]}
+     *
+     * @throws BusinessException 配对码无效/过期/已用，或缺少必要字段
+     */
+    public static function register(array $payload): array
+    {
+        $code = trim((string)($payload['provision_code'] ?? ''));
+        if ($code === '') {
+            throw new BusinessException('缺少配对码', 422, 9002);
+        }
+
+        $record = ProvisionCode::where('code', $code)->first();
+        if (!$record) {
+            throw new BusinessException('配对码无效', 422, 9003);
+        }
+        if ($record->status !== ProvisionCode::STATUS_PENDING) {
+            throw new BusinessException('配对码已被使用', 410, 9004);
+        }
+        if (strtotime((string)$record->expires_at) < time()) {
+            $record->update(['status' => ProvisionCode::STATUS_EXPIRED]);
+            throw new BusinessException('配对码已过期', 410, 9005);
+        }
+
+        $gw = $payload['gateway'] ?? [];
+        $gwUid = trim((string)($gw['device_uid'] ?? ''));
+        if ($gwUid === '') {
+            throw new BusinessException('缺少网关 device_uid', 422, 9006);
+        }
+
+        // 网关 MQTT 明文密码（仅在响应里返回一次，库里只存 bcrypt）
+        $mqttPassword = bin2hex(random_bytes(16));
+
+        // 多表写入用事务（用模型自身连接，兼容生产 PgSQL 与测试 SQLite）
+        $devices = Device::getConnection()->transaction(function () use ($record, $gw, $gwUid, $payload, $mqttPassword) {
+            $created = [];
+
+            // 1. 网关（幂等 upsert：支持恢复出厂后重新配网）
+            $gwData = [
+                'device_uid'         => $gwUid,
+                'name'               => $gw['name'] ?? $gwUid,
+                'type'               => 'gateway',
+                'location'           => $record->location,
+                'firmware_version'   => $gw['firmware_version'] ?? null,
+                'mqtt_username'      => $gwUid,
+                'mqtt_password_hash' => password_hash($mqttPassword, PASSWORD_BCRYPT),
+            ];
+            if (array_key_exists('capability', $gw)) {
+                $gwData['capability'] = $gw['capability'];
+            }
+            $gateway = self::upsertDevice($gwUid, $gwData);
+            $created[] = ['device_uid' => $gwUid, 'id' => $gateway->id, 'role' => 'gateway'];
+
+            // 2. 子传感器/子设备
+            foreach (($payload['sensors'] ?? []) as $i => $s) {
+                $sUid = trim((string)($s['device_uid'] ?? '')) ?: ($gwUid . '-s' . ($i + 1));
+                $sData = [
+                    'device_uid'    => $sUid,
+                    'name'          => $s['name'] ?? $sUid,
+                    'type'          => $s['type'] ?? 'sensor',
+                    'location'      => $record->location,
+                    'gateway_uid'   => $gwUid,
+                    'mqtt_username' => $sUid, // 子设备不连 MQTT，但保持列唯一
+                ];
+                if (array_key_exists('metric_fields', $s)) {
+                    $sData['metric_fields'] = $s['metric_fields'];
+                }
+                if (array_key_exists('capability', $s)) {
+                    $sData['capability'] = $s['capability'];
+                }
+                $sensor = self::upsertDevice($sUid, $sData);
+                $created[] = ['device_uid' => $sUid, 'id' => $sensor->id, 'role' => $sData['type']];
+            }
+
+            // 3. 标记配对码已用
+            $record->update([
+                'status'     => ProvisionCode::STATUS_REGISTERED,
+                'device_uid' => $gwUid,
+                'used_at'    => now(),
+            ]);
+
+            return $created;
+        });
+
+        return [
+            'mqtt' => [
+                // 返回设备可达的公网 MQTT 地址；MQTT_PUBLIC_HOST 未配则回退 MQTT_HOST
+                'host'     => getenv('MQTT_PUBLIC_HOST') ?: (getenv('MQTT_HOST') ?: 'emqx'),
+                'port'     => (int)(getenv('MQTT_PORT') ?: 1883),
+                'username' => $gwUid,
+                'password' => $mqttPassword,
+            ],
+            'gateway_uid' => $gwUid,
+            'devices'     => $devices,
+        ];
+    }
+
+    /**
+     * 按 device_uid upsert 一台设备
+     */
+    private static function upsertDevice(string $uid, array $data): Device
+    {
+        $device = Device::where('device_uid', $uid)->first();
+        if ($device) {
+            $device->update($data);
+            return $device;
+        }
+        return Device::create($data);
+    }
+
+    /**
+     * 查询配对码状态（供移动端轮询）
+     *
+     * @param  string $code   配对码
+     * @param  int    $userId 当前用户（仅能查自己的码）
+     * @return array {status, device|null}
+     *
+     * @throws BusinessException 码不存在
+     */
+    public static function statusOf(string $code, int $userId): array
+    {
+        $record = ProvisionCode::where('code', $code)->where('user_id', $userId)->first();
+        if (!$record) {
+            throw new BusinessException('配对码不存在', 404, 9007);
+        }
+
+        $status = $record->status;
+        if ($status === ProvisionCode::STATUS_PENDING && strtotime((string)$record->expires_at) < time()) {
+            $status = ProvisionCode::STATUS_EXPIRED;
+        }
+
+        $device = null;
+        if ($record->device_uid) {
+            $d = Device::where('device_uid', $record->device_uid)
+                ->first(['id', 'device_uid', 'name', 'is_online']);
+            $device = $d ? $d->toArray() : null;
+        }
+
+        return ['status' => $status, 'device' => $device];
+    }
+}

--- a/config/route.php
+++ b/config/route.php
@@ -168,6 +168,15 @@ Route::group('/api/mqtt', function () {
 
 /*
 |--------------------------------------------------------------------------
+| 设备自注册（公开，凭配对码信任；同 MQTT 回调不走 JWT）
+|--------------------------------------------------------------------------
+*/
+Route::group('/api/provisioning', function () {
+    Route::post('/register', [app\controller\ProvisioningController::class, 'register']);
+});
+
+/*
+|--------------------------------------------------------------------------
 | 需要认证的接口（JWT 中间件）
 |--------------------------------------------------------------------------
 */
@@ -179,6 +188,11 @@ Route::group('/api', function () {
     Route::post('/auth/logout-all', [app\controller\AuthController::class, 'logoutAll']);
     Route::post('/auth/change-password', [app\controller\AuthController::class, 'changePassword'])
         ->middleware([AuditLogMiddleware::class]);
+
+    /* ---------- 设备配网（生成配对码 / 轮询状态） ---------- */
+    Route::post('/provisioning/codes', [app\controller\ProvisioningController::class, 'createCode'])
+        ->middleware([new PermissionMiddleware('devices.create')]);
+    Route::get('/provisioning/codes/{code}/status', [app\controller\ProvisioningController::class, 'status']);
 
     /* ---------- 指标定义 ---------- */
     Route::get('/metric-definitions', [app\controller\MetricDefinitionController::class, 'index'])

--- a/database/php-migrations/2026_07_08_000001_create_provision_codes_table.php
+++ b/database/php-migrations/2026_07_08_000001_create_provision_codes_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Eloquent\Migrations\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->schema()->create('provision_codes', function (Blueprint $table) {
+            $table->id();
+            $table->string('code', 16)->unique()->comment('配对码（一次性、短时有效）');
+            $table->unsignedBigInteger('user_id')->comment('生成该码的用户');
+            $table->string('location', 100)->nullable()->comment('预设设备位置');
+            $table->string('status', 20)->default('pending')->comment('pending / registered / expired');
+            $table->string('device_uid', 64)->nullable()->comment('注册成功后回填的网关 device_uid');
+            $table->timestampTz('expires_at')->comment('过期时间');
+            $table->timestampTz('used_at')->nullable()->comment('被设备使用的时间');
+            $table->timestampsTz();
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->index('expires_at');
+        });
+    }
+
+    public function down(): void
+    {
+        $this->schema()->dropIfExists('provision_codes');
+    }
+};

--- a/tests/Unit/ProvisioningServiceTest.php
+++ b/tests/Unit/ProvisioningServiceTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use app\service\ProvisioningService;
+use app\model\ProvisionCode;
+use app\model\Device;
+use app\exception\BusinessException;
+
+/**
+ * 设备自助配网服务测试（基于 SQLite 内存库）
+ */
+class ProvisioningServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Device::query()->delete();
+        ProvisionCode::query()->delete();
+    }
+
+    /* ============ createCode ============ */
+
+    public function test_create_code_format_and_persist(): void
+    {
+        $rec = ProvisioningService::createCode(1, '客厅');
+
+        $this->assertMatchesRegularExpression('/^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/', $rec->code);
+        $this->assertEquals('pending', $rec->status);
+        $this->assertEquals('客厅', $rec->location);
+        $this->assertEquals(1, $rec->user_id);
+        // 未来某个时间过期
+        $this->assertGreaterThan(time(), strtotime((string)$rec->expires_at));
+        // 落库
+        $this->assertTrue(ProvisionCode::where('code', $rec->code)->exists());
+    }
+
+    public function test_create_code_empty_location_is_null(): void
+    {
+        $rec = ProvisioningService::createCode(1, '');
+        $this->assertNull($rec->location);
+    }
+
+    /* ============ register 成功 ============ */
+
+    public function test_register_creates_gateway_and_sensors(): void
+    {
+        $code = ProvisioningService::createCode(7, '书房')->code;
+
+        $result = ProvisioningService::register([
+            'provision_code' => $code,
+            'gateway' => ['device_uid' => 'esp32-aabbcc', 'name' => '书房网关', 'firmware_version' => '1.2.0'],
+            'sensors' => [
+                ['device_uid' => 'esp32-aabbcc-temp', 'name' => '温湿度', 'type' => 'sensor'],
+                ['name' => '噪音', 'type' => 'sensor'], // 不给 uid → 自动生成
+            ],
+        ]);
+
+        // 返回 MQTT 凭证
+        $this->assertSame('esp32-aabbcc', $result['mqtt']['username']);
+        $this->assertNotEmpty($result['mqtt']['password']);
+        $this->assertSame('esp32-aabbcc', $result['gateway_uid']);
+        $this->assertCount(3, $result['devices']); // 1 网关 + 2 传感器
+
+        // 网关落库正确
+        $gw = Device::where('device_uid', 'esp32-aabbcc')->first();
+        $this->assertNotNull($gw);
+        $this->assertSame('gateway', $gw->type);
+        $this->assertSame('书房', $gw->location);
+        $this->assertNotEmpty($gw->mqtt_password_hash);
+        // 明文不入库，仅哈希；且能校验通过
+        $this->assertTrue(password_verify($result['mqtt']['password'], $gw->mqtt_password_hash));
+
+        // 传感器挂在网关下、继承位置、自动 uid
+        $s1 = Device::where('device_uid', 'esp32-aabbcc-temp')->first();
+        $this->assertSame('esp32-aabbcc', $s1->gateway_uid);
+        $this->assertSame('书房', $s1->location);
+        $this->assertNotNull(Device::where('device_uid', 'esp32-aabbcc-s2')->first());
+
+        // 配对码标记已用
+        $rec = ProvisionCode::where('code', $code)->first();
+        $this->assertSame('registered', $rec->status);
+        $this->assertSame('esp32-aabbcc', $rec->device_uid);
+        $this->assertNotNull($rec->used_at);
+    }
+
+    public function test_register_is_idempotent_upsert(): void
+    {
+        $code1 = ProvisioningService::createCode(1, 'A')->code;
+        ProvisioningService::register([
+            'provision_code' => $code1,
+            'gateway' => ['device_uid' => 'esp32-dup', 'name' => '旧名'],
+        ]);
+
+        // 同一设备重新配网（新码）→ upsert，不报错，名称/位置更新
+        $code2 = ProvisioningService::createCode(1, 'B')->code;
+        ProvisioningService::register([
+            'provision_code' => $code2,
+            'gateway' => ['device_uid' => 'esp32-dup', 'name' => '新名'],
+        ]);
+
+        $this->assertSame(1, Device::where('device_uid', 'esp32-dup')->count());
+        $gw = Device::where('device_uid', 'esp32-dup')->first();
+        $this->assertSame('新名', $gw->name);
+        $this->assertSame('B', $gw->location);
+    }
+
+    /* ============ register 拒绝 ============ */
+
+    public function test_register_rejects_missing_code(): void
+    {
+        $this->expectException(BusinessException::class);
+        ProvisioningService::register(['gateway' => ['device_uid' => 'x']]);
+    }
+
+    public function test_register_rejects_invalid_code(): void
+    {
+        $this->expectException(BusinessException::class);
+        ProvisioningService::register([
+            'provision_code' => 'NOTACODE',
+            'gateway' => ['device_uid' => 'x'],
+        ]);
+    }
+
+    public function test_register_rejects_used_code(): void
+    {
+        $code = ProvisioningService::createCode(1, null)->code;
+        ProvisioningService::register([
+            'provision_code' => $code,
+            'gateway' => ['device_uid' => 'esp32-first'],
+        ]);
+
+        // 再次使用同一码 → 已注册，拒绝
+        $this->expectException(BusinessException::class);
+        ProvisioningService::register([
+            'provision_code' => $code,
+            'gateway' => ['device_uid' => 'esp32-second'],
+        ]);
+    }
+
+    public function test_register_rejects_expired_code(): void
+    {
+        // 手动造一个已过期的 pending 码
+        $rec = ProvisionCode::create([
+            'code'       => 'EXPIRED1',
+            'user_id'    => 1,
+            'status'     => ProvisionCode::STATUS_PENDING,
+            'expires_at' => date('Y-m-d H:i:s', time() - 60),
+        ]);
+
+        try {
+            ProvisioningService::register([
+                'provision_code' => 'EXPIRED1',
+                'gateway' => ['device_uid' => 'esp32-x'],
+            ]);
+            $this->fail('过期码应被拒绝');
+        } catch (BusinessException $e) {
+            // 并被标记为 expired
+            $this->assertSame(ProvisionCode::STATUS_EXPIRED, ProvisionCode::where('code', 'EXPIRED1')->first()->status);
+        }
+    }
+
+    public function test_register_rejects_missing_gateway_uid(): void
+    {
+        $code = ProvisioningService::createCode(1, null)->code;
+        $this->expectException(BusinessException::class);
+        ProvisioningService::register(['provision_code' => $code, 'gateway' => []]);
+    }
+
+    /* ============ statusOf ============ */
+
+    public function test_status_pending_then_registered(): void
+    {
+        $code = ProvisioningService::createCode(5, '厨房')->code;
+
+        $s1 = ProvisioningService::statusOf($code, 5);
+        $this->assertSame('pending', $s1['status']);
+        $this->assertNull($s1['device']);
+
+        ProvisioningService::register([
+            'provision_code' => $code,
+            'gateway' => ['device_uid' => 'esp32-kitchen', 'name' => '厨房网关'],
+        ]);
+
+        $s2 = ProvisioningService::statusOf($code, 5);
+        $this->assertSame('registered', $s2['status']);
+        $this->assertSame('esp32-kitchen', $s2['device']['device_uid']);
+    }
+
+    public function test_status_rejects_other_users_code(): void
+    {
+        $code = ProvisioningService::createCode(5, null)->code;
+        $this->expectException(BusinessException::class);
+        ProvisioningService::statusOf($code, 999); // 不是本人
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -51,9 +51,25 @@ $capsule->schema()->create('devices', function ($table) {
     $table->string('firmware_version')->nullable();
     $table->string('mqtt_username')->default('');
     $table->string('mqtt_password_hash')->nullable();
+    $table->string('gateway_uid')->nullable();
+    $table->text('metric_fields')->nullable();
+    $table->text('capability')->nullable();
     $table->boolean('is_online')->default(false);
     $table->timestamp('last_seen')->nullable();
     $table->boolean('is_active')->default(true);
+    $table->timestamps();
+});
+
+// provision_codes 表（设备配网）
+$capsule->schema()->create('provision_codes', function ($table) {
+    $table->id();
+    $table->string('code')->unique();
+    $table->unsignedBigInteger('user_id');
+    $table->string('location')->nullable();
+    $table->string('status')->default('pending');
+    $table->string('device_uid')->nullable();
+    $table->timestamp('expires_at');
+    $table->timestamp('used_at')->nullable();
     $table->timestamps();
 });
 


### PR DESCRIPTION
让设备凭"配对码"自注册，免去手工建设备/设 MQTT 密码/烧录 config。

- 迁移 provision_codes 表（配对码：一次性、10min TTL、绑用户+位置）
- ProvisionCode 模型
- ProvisioningService: 生成码 / 设备自注册（建网关+子传感器、生成MQTT凭证、 幂等 upsert 支持恢复出厂重配）/ 轮询状态
- ProvisioningController: POST /api/provisioning/codes（登录+devices.create）、 GET .../codes/{code}/status（登录）、POST /api/provisioning/register（公开，凭码信任）
- 路由注册；复用现有网关-子设备模型与 EMQX bcrypt 认证（零改动）
- 测试 bootstrap 补 provision_codes 表与 devices 的 gateway_uid/capability/metric_fields 列
- ProvisioningServiceTest：创建码/注册成功/幂等/各类拒绝(无效/过期/已用/缺字段)/状态轮询/越权

安全：配对码 8 位高熵+TTL+一次性；注册响应含明文 MQTT 密码，生产需 HTTPS，
建议对 register 加 IP 限流（已在代码注释标注）。固件与移动端页面另议。

<!-- 感谢贡献！请填写以下信息，便于评审。 -->

## 这个 PR 做了什么

<!-- 简述动机与改动内容 -->

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构 / 性能
- [ ] 文档
- [ ] 构建 / CI / 其他

## 自检清单

- [ ] 后端：`php -l` 通过，`composer test`（PHPUnit）通过
- [ ] 移动端（如涉及）：`npx tsc --noEmit` 与 `npm run build` 通过
- [ ] 已为新增/变更逻辑补充或更新测试（如适用）
- [ ] 已更新相关文档（README / 蓝图等）

## 部署影响

<!-- 是否需要：新数据库迁移 / 新环境变量 / 新进程 / 重新构建移动端？没有则写「无」 -->

## 关联 Issue

<!-- Closes #123 -->
