### PR TITLE
fix(provisioning): getConnection 不能静态调用导致注册 500

### DIFF
--- a/app/service/ProvisioningService.php
+++ b/app/service/ProvisioningService.php
@@ -101,8 +101,9 @@ class ProvisioningService
         // 网关 MQTT 明文密码（仅在响应里返回一次，库里只存 bcrypt）
         $mqttPassword = bin2hex(random_bytes(16));
 
-        // 多表写入用事务（用模型自身连接，兼容生产 PgSQL 与测试 SQLite）
-        $devices = Device::getConnection()->transaction(function () use ($record, $gw, $gwUid, $payload, $mqttPassword) {
+        // 多表写入用事务（用模型实例的连接，兼容生产 PgSQL 与测试 SQLite；
+        // getConnection() 是实例方法，不能静态调用）
+        $devices = (new Device)->getConnection()->transaction(function () use ($record, $gw, $gwUid, $payload, $mqttPassword) {
             $created = [];
 
             // 1. 网关（幂等 upsert：支持恢复出厂后重新配网）


### PR DESCRIPTION
Device::getConnection() 是 Eloquent 实例方法，静态调用抛
"cannot be called statically"，使 /api/provisioning/register 500。 改为 (new Device)->getConnection()->transaction(...)。

<!-- 感谢贡献！请填写以下信息，便于评审。 -->

## 这个 PR 做了什么

<!-- 简述动机与改动内容 -->

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构 / 性能
- [ ] 文档
- [ ] 构建 / CI / 其他

## 自检清单

- [ ] 后端：`php -l` 通过，`composer test`（PHPUnit）通过
- [ ] 移动端（如涉及）：`npx tsc --noEmit` 与 `npm run build` 通过
- [ ] 已为新增/变更逻辑补充或更新测试（如适用）
- [ ] 已更新相关文档（README / 蓝图等）

## 部署影响

<!-- 是否需要：新数据库迁移 / 新环境变量 / 新进程 / 重新构建移动端？没有则写「无」 -->

## 关联 Issue

<!-- Closes #123 -->
