### PR TITLE
feat(firmware): ESP32 SoftAP 自助配网 + 自注册握手

### DIFF
--- a/firmware/include/config.example.h
+++ b/firmware/include/config.example.h
@@ -1,31 +1,55 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-// ─── WiFi ─────────────────────────────────────────────
-#define WIFI_SSID              "YourWiFi"
-#define WIFI_PASSWORD          "YourPassword"
+// =====================================================================
+//  编译期配置（硬件 / 构建相关）
+// =====================================================================
 
-// ─── MQTT Broker ──────────────────────────────────────
-#define MQTT_HOST              "192.168.1.100"
-#define MQTT_PORT              1883
-
-// ─── 网关标识（用于 MQTT 认证）────────────────────────
-#define GATEWAY_UID            "gw-001"
-#define MQTT_PASSWORD          "gateway_password"
+// ─── 固件版本 ─────────────────────────────────────────
+#define FIRMWARE_VERSION       "1.1.0"
 
 // ─── 上报间隔（毫秒）─────────────────────────────────
 #define TELEMETRY_INTERVAL_MS  5000
 
-// ─── 传感器模块（每个传感器有独立的 device_uid）──────
+// ─── 恢复出厂按键（长按 5 秒清空配置重新配网）────────
+#define FACTORY_RESET_PIN      0    // BOOT 键
+
+// ─── 平台地址：SoftAP 配网页会预填此值（用户可改）────
+//  自助配网时设备用它调 /api/provisioning/register。
+//  生产建议 https（注册响应含明文 MQTT 密码）。
+#define DEFAULT_SERVER_URL     "https://your-server"
+
+// ─── 传感器模块（引脚 / 使能，编译期决定接了哪些）────
 #define SENSOR_DHT11_ENABLED   1
-#define SENSOR_DHT11_UID       "sensor-temp-01"
 #define DHT11_PIN              4    // GPIO4
 
 #define SENSOR_SOUND_ENABLED   1
-#define SENSOR_SOUND_UID       "sensor-sound-01"
 #define SOUND_SENSOR_PIN       34   // GPIO34 (ADC1)
 
-// ─── 固件版本 ─────────────────────────────────────────
-#define FIRMWARE_VERSION       "1.0.0"
+//  传感器 device_uid：默认由网关 UID 自动派生（如 esp32-aabbcc-temp）。
+//  一般无需指定；仅当你要沿用后台已存在的固定 uid 时才取消注释：
+// #define SENSOR_DHT11_UID    "sensor-temp-01"
+// #define SENSOR_SOUND_UID    "sensor-sound-01"
+
+// =====================================================================
+//  运行期配置（WiFi / MQTT 身份）
+// =====================================================================
+//
+//  【推荐】自助配网：保持下面 WiFi 为占位值 "YourWiFi"，设备首次开机会进入
+//   SoftAP 配网模式（热点 HG-Setup-xxxx），在手机 App「添加设备」生成配对码，
+//   通过配网页填入即可自动注册上线，无需在此填写任何凭证。
+//
+//  【可选】手动烧录（向后兼容旧流程）：若在此填入真实 WiFi（及可选的 MQTT
+//   凭证），设备将跳过配网直接连接。留占位值则走自助配网。
+//   网关 UID 未指定时自动用 MAC 派生（esp32-<mac>）。
+
+#define WIFI_SSID              "YourWiFi"
+#define WIFI_PASSWORD          "YourPassword"
+
+//  可选：连同 MQTT 凭证一起写死（则跳过自注册，需先在后台手动建设备）
+#define MQTT_HOST              "192.168.1.100"
+#define MQTT_PORT              1883
+#define GATEWAY_UID            "gw-001"
+#define MQTT_PASSWORD          "gateway_password"
 
 #endif // CONFIG_H

--- a/firmware/include/config_store.h
+++ b/firmware/include/config_store.h
@@ -1,0 +1,53 @@
+#ifndef CONFIG_STORE_H
+#define CONFIG_STORE_H
+
+#include <Arduino.h>
+#include <Preferences.h>
+
+/**
+ * 运行期配置存储（ESP32 NVS / Preferences）
+ *
+ * 把 WiFi、平台地址、配对码、MQTT 凭证、网关 UID 从编译期(config.h)搬到运行期，
+ * 支撑自助配网。首次为空时若 config.h 填了真实凭证，则从 config.h 播种（兼容旧的手动烧录流程）。
+ */
+class ConfigStore {
+public:
+    void begin();
+
+    bool hasWifi() const { return _ssid.length() > 0; }
+    bool hasMqtt() const { return _mqttUser.length() > 0 && _mqttPass.length() > 0; }
+
+    const String& wifiSsid()      const { return _ssid; }
+    const String& wifiPass()      const { return _pass; }
+    const String& serverUrl()     const { return _serverUrl; }
+    const String& provisionCode() const { return _code; }
+    const String& mqttHost()      const { return _mqttHost; }
+    uint16_t      mqttPort()      const { return _mqttPort; }
+    const String& mqttUser()      const { return _mqttUser; }
+    const String& mqttPass()      const { return _mqttPass; }
+    const String& gatewayUid()    const { return _gatewayUid; }
+
+    // 配网页提交后保存（WiFi + 平台地址 + 配对码），随后重启进入注册
+    void saveProvisioning(const String& ssid, const String& pass,
+                          const String& serverUrl, const String& code);
+
+    // 注册成功后保存 MQTT 凭证
+    void saveMqtt(const String& host, uint16_t port,
+                  const String& user, const String& pass);
+
+    // 恢复出厂：清空全部
+    void clearAll();
+
+    // MAC 派生的稳定设备 UID：esp32-aabbcc（无需预配置即唯一）
+    static String deviceUid();
+
+private:
+    Preferences _prefs;
+    String _ssid, _pass, _serverUrl, _code;
+    String _mqttHost, _mqttUser, _mqttPass, _gatewayUid;
+    uint16_t _mqttPort = 1883;
+
+    void load();
+};
+
+#endif // CONFIG_STORE_H

--- a/firmware/include/mqtt_manager.h
+++ b/firmware/include/mqtt_manager.h
@@ -1,6 +1,7 @@
 #ifndef MQTT_MANAGER_H
 #define MQTT_MANAGER_H
 
+#include <Arduino.h>
 #include <WiFiClient.h>
 #include <PubSubClient.h>
 
@@ -31,10 +32,11 @@ private:
     char _gatewayStateTopic[80];
     char _gatewayCommandSub[80];
     char _gatewayCommandReply[80];
-    const char* _host = nullptr;
+    // 存 String 拷贝：凭证来自运行期(NVS)的临时 buffer，不能存裸指针
+    String _host;
     uint16_t _port = 1883;
-    const char* _gatewayUid = nullptr;
-    const char* _password = nullptr;
+    String _gatewayUid;
+    String _password;
     unsigned long _lastReconnect = 0;
     unsigned long _reconnectInterval = 5000;
     CommandCallback _commandCb = nullptr;

--- a/firmware/include/provisioning.h
+++ b/firmware/include/provisioning.h
@@ -1,0 +1,33 @@
+#ifndef PROVISIONING_H
+#define PROVISIONING_H
+
+#include <Arduino.h>
+#include <WebServer.h>
+#include <DNSServer.h>
+#include "config_store.h"
+
+/**
+ * SoftAP 配网门户（captive portal）
+ *
+ * 无 WiFi 凭证时进入：开热点 HG-Setup-xxxx，DNS 全劫持到 192.168.4.1，
+ * 设备自托管配网页。用户填家里 WiFi + 粘贴配对码 + 平台地址后提交，
+ * 存入 NVS 并置 done，由 main 重启进入注册。
+ */
+class Provisioning {
+public:
+    void begin(ConfigStore* store);
+    void loop();
+    bool isDone() const { return _done; }
+
+private:
+    ConfigStore* _store = nullptr;
+    WebServer _server{80};
+    DNSServer _dns;
+    bool _done = false;
+
+    void handleRoot();
+    void handleScan();
+    void handleProvision();
+};
+
+#endif // PROVISIONING_H

--- a/firmware/include/registration.h
+++ b/firmware/include/registration.h
@@ -1,0 +1,17 @@
+#ifndef REGISTRATION_H
+#define REGISTRATION_H
+
+#include "config_store.h"
+#include "sensor_registry.h"
+
+/**
+ * 设备自注册：连上 WiFi 后凭配对码向平台注册，拿回 MQTT 凭证并存入 NVS。
+ * POST {server_url}/api/provisioning/register
+ */
+class Registration {
+public:
+    // 成功返回 true（MQTT 凭证已保存）
+    static bool run(ConfigStore& store, SensorRegistry& sensors, const char* firmwareVersion);
+};
+
+#endif // REGISTRATION_H

--- a/firmware/include/wifi_manager.h
+++ b/firmware/include/wifi_manager.h
@@ -1,6 +1,8 @@
 #ifndef WIFI_MANAGER_H
 #define WIFI_MANAGER_H
 
+#include <Arduino.h>
+
 class WifiManager {
 public:
     void begin(const char* ssid, const char* password);
@@ -8,8 +10,9 @@ public:
     bool isConnected();
 
 private:
-    const char* _ssid = nullptr;
-    const char* _password = nullptr;
+    // 存 String 拷贝：凭证来自运行期(NVS)的临时 buffer，不能存裸指针
+    String _ssid;
+    String _password;
     unsigned long _lastCheck = 0;
     static constexpr unsigned long CHECK_INTERVAL_MS = 10000;
 };

--- a/firmware/src/config_store.cpp
+++ b/firmware/src/config_store.cpp
@@ -1,0 +1,92 @@
+#include "config_store.h"
+#include <WiFi.h>
+#include "config.h"
+
+static const char* NS = "hg";  // Preferences 命名空间
+
+void ConfigStore::begin() {
+    _gatewayUid = deviceUid();  // 默认用 MAC 派生
+    load();
+
+    // ── 向后兼容：NVS 为空但 config.h 填了真实 WiFi → 从 config.h 播种（旧的手动烧录流程仍可用）
+#if defined(WIFI_SSID)
+    if (_ssid.length() == 0 && strlen(WIFI_SSID) > 0 && strcmp(WIFI_SSID, "YourWiFi") != 0) {
+        String surl = "";
+#ifdef DEFAULT_SERVER_URL
+        surl = DEFAULT_SERVER_URL;
+#endif
+        saveProvisioning(WIFI_SSID, WIFI_PASSWORD, surl, "");
+
+        // 若 config.h 也给了真实 MQTT 凭证，则一并播种 → 直接进 NORMAL，跳过自注册
+#if defined(MQTT_PASSWORD) && defined(GATEWAY_UID) && defined(MQTT_HOST)
+        if (strlen(MQTT_PASSWORD) > 0 && strcmp(MQTT_PASSWORD, "gateway_password") != 0) {
+            _gatewayUid = GATEWAY_UID;
+            _prefs.begin(NS, false);
+            _prefs.putString("guid", _gatewayUid);
+            _prefs.end();
+            saveMqtt(MQTT_HOST, MQTT_PORT, GATEWAY_UID, MQTT_PASSWORD);
+        }
+#endif
+    }
+#endif
+}
+
+void ConfigStore::load() {
+    _prefs.begin(NS, true);  // 只读
+    _ssid      = _prefs.getString("ssid", "");
+    _pass      = _prefs.getString("pass", "");
+    _serverUrl = _prefs.getString("surl", "");
+    _code      = _prefs.getString("pcode", "");
+    _mqttHost  = _prefs.getString("mhost", "");
+    _mqttPort  = _prefs.getUShort("mport", 1883);
+    _mqttUser  = _prefs.getString("muser", "");
+    _mqttPass  = _prefs.getString("mpass", "");
+    String guid = _prefs.getString("guid", "");
+    _prefs.end();
+    if (guid.length() > 0) _gatewayUid = guid;
+}
+
+void ConfigStore::saveProvisioning(const String& ssid, const String& pass,
+                                   const String& serverUrl, const String& code) {
+    _prefs.begin(NS, false);
+    _prefs.putString("ssid", ssid);
+    _prefs.putString("pass", pass);
+    _prefs.putString("surl", serverUrl);
+    _prefs.putString("pcode", code);
+    _prefs.putString("guid", _gatewayUid);
+    _prefs.end();
+
+    _ssid = ssid; _pass = pass; _serverUrl = serverUrl; _code = code;
+}
+
+void ConfigStore::saveMqtt(const String& host, uint16_t port,
+                           const String& user, const String& pass) {
+    _prefs.begin(NS, false);
+    _prefs.putString("mhost", host);
+    _prefs.putUShort("mport", port);
+    _prefs.putString("muser", user);
+    _prefs.putString("mpass", pass);
+    _prefs.end();
+
+    _mqttHost = host; _mqttPort = port; _mqttUser = user; _mqttPass = pass;
+}
+
+void ConfigStore::clearAll() {
+    _prefs.begin(NS, false);
+    _prefs.clear();
+    _prefs.end();
+    _ssid = ""; _pass = ""; _serverUrl = ""; _code = "";
+    _mqttHost = ""; _mqttUser = ""; _mqttPass = "";
+    // gatewayUid 保持 MAC 派生（稳定）
+    _gatewayUid = deviceUid();
+}
+
+String ConfigStore::deviceUid() {
+    uint64_t mac = ESP.getEfuseMac();
+    char buf[20];
+    snprintf(buf, sizeof(buf), "esp32-%02x%02x%02x",
+             (uint8_t)(mac & 0xFF),
+             (uint8_t)((mac >> 8) & 0xFF),
+             (uint8_t)((mac >> 16) & 0xFF));
+    return String(buf);
+}

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,8 +1,12 @@
 /**
  * Home Guardian - ESP32 网关固件
  *
- * ESP32 作为网关，代其下挂载的传感器设备上报遥测数据和状态。
- * 每个传感器有独立的 device_uid，通过网关的 MQTT 连接发布。
+ * 支持两种上线方式：
+ *   1. 自助配网（无凭证时）：SoftAP 配网页 → 填 WiFi + 配对码 → 自注册拿 MQTT 凭证 → 上线
+ *   2. 手动烧录（config.h 填了真实凭证）：直接连接（向后兼容）
+ *
+ * 启动状态机（见 setup）：无 WiFi → 配网模式；有 WiFi 无 MQTT → 注册；齐全 → 正常运行。
+ * 长按 BOOT 键 5 秒恢复出厂（清空 NVS 重新配网）。
  */
 
 #include <Arduino.h>
@@ -14,6 +18,9 @@
 #include "mqtt_manager.h"
 #include "sensor_registry.h"
 #include "command_handler.h"
+#include "config_store.h"
+#include "provisioning.h"
+#include "registration.h"
 
 #if SENSOR_DHT11_ENABLED
 #include "sensor_dht11.h"
@@ -22,13 +29,23 @@
 #include "sensor_sound.h"
 #endif
 
-WifiManager wifi;
-MqttManager mqtt;
+#ifndef FACTORY_RESET_PIN
+#define FACTORY_RESET_PIN 0   // BOOT 键
+#endif
+
+WifiManager  wifi;
+MqttManager  mqtt;
 SensorRegistry sensors;
 CommandHandler commands;
+ConfigStore  store;
+Provisioning provisioning;
+
+enum Mode { MODE_PROVISION, MODE_NORMAL };
+Mode mode = MODE_NORMAL;
 
 unsigned long lastTelemetry = 0;
 bool sensorsOnlinePublished = false;
+unsigned long btnPressStart = 0;
 
 // ─── 内置指令处理器 ──────────────────────────────────────
 
@@ -37,11 +54,11 @@ bool handlePing(const JsonObject& params, JsonObject& response) {
 }
 
 bool handleGetInfo(const JsonObject& params, JsonObject& response) {
-    response["firmware"]    = FIRMWARE_VERSION;
-    response["gateway_uid"] = GATEWAY_UID;
-    response["uptime_s"]    = (long)(millis() / 1000);
-    response["free_heap"]   = (long)ESP.getFreeHeap();
-    response["wifi_rssi"]   = (long)WiFi.RSSI();
+    response["firmware"]     = FIRMWARE_VERSION;
+    response["gateway_uid"]  = store.gatewayUid();
+    response["uptime_s"]     = (long)(millis() / 1000);
+    response["free_heap"]    = (long)ESP.getFreeHeap();
+    response["wifi_rssi"]    = (long)WiFi.RSSI();
     response["sensor_count"] = sensors.count();
     return true;
 }
@@ -53,6 +70,96 @@ bool handleReboot(const JsonObject& params, JsonObject& response) {
     return true;
 }
 
+// ─── 传感器注册（uid 优先用 config.h 指定，否则由网关 uid 派生）──────
+
+void registerSensors() {
+    String gw = store.gatewayUid();
+
+#if SENSOR_DHT11_ENABLED
+    {
+    #ifdef SENSOR_DHT11_UID
+        static String dhtUid = SENSOR_DHT11_UID;
+    #else
+        static String dhtUid = gw + "-temp";
+    #endif
+        static SensorDHT11 dht(DHT11_PIN, dhtUid.c_str());
+        sensors.registerSensor(&dht);
+    }
+#endif
+#if SENSOR_SOUND_ENABLED
+    {
+    #ifdef SENSOR_SOUND_UID
+        static String soundUid = SENSOR_SOUND_UID;
+    #else
+        static String soundUid = gw + "-sound";
+    #endif
+        static SensorSound sound(SOUND_SENSOR_PIN, soundUid.c_str());
+        sensors.registerSensor(&sound);
+    }
+#endif
+
+    sensors.beginAll();
+    Serial.printf("[Main] 已注册 %d 个传感器\n", sensors.count());
+}
+
+// ─── 正常运行启动：连 WiFi →（必要时注册）→ 连 MQTT ──────
+
+void startNormal() {
+    wifi.begin(store.wifiSsid().c_str(), store.wifiPass().c_str());
+
+    // 无 MQTT 凭证 → 先自注册
+    if (!store.hasMqtt()) {
+        Serial.println("[Main] 无 MQTT 凭证，等待 WiFi 后自注册...");
+        unsigned long t = millis();
+        while (!wifi.isConnected() && millis() - t < 30000) {
+            delay(500);
+            watchdog_feed();
+        }
+        if (!wifi.isConnected()) {
+            Serial.println("[Main] WiFi 连接失败，重启重试");
+            delay(2000);
+            ESP.restart();
+        }
+
+        int tries = 0;
+        while (!store.hasMqtt() && tries < 5) {
+            if (Registration::run(store, sensors, FIRMWARE_VERSION)) break;
+            tries++;
+            Serial.printf("[Main] 注册失败(%d/5)，3 秒后重试\n", tries);
+            delay(3000);
+            watchdog_feed();
+        }
+        if (!store.hasMqtt()) {
+            Serial.println("[Main] 多次注册失败，重启重试");
+            delay(2000);
+            ESP.restart();
+        }
+    }
+
+    mqtt.begin(store.mqttHost().c_str(), store.mqttPort(),
+               store.gatewayUid().c_str(), store.mqttPass().c_str());
+    mqtt.onCommand([](const char* payload, unsigned int len) {
+        commands.handle(payload, len, mqtt);
+    });
+}
+
+// ─── 恢复出厂：长按 BOOT 键 5 秒 ──────
+
+void checkFactoryReset() {
+    if (digitalRead(FACTORY_RESET_PIN) == LOW) {
+        if (btnPressStart == 0) {
+            btnPressStart = millis();
+        } else if (millis() - btnPressStart > 5000) {
+            Serial.println("[Main] 恢复出厂：清空配置并重启");
+            store.clearAll();
+            delay(500);
+            ESP.restart();
+        }
+    } else {
+        btnPressStart = 0;
+    }
+}
+
 // ─── setup / loop ────────────────────────────────────────
 
 void setup() {
@@ -60,47 +167,47 @@ void setup() {
     delay(100);
     Serial.println("\n=============================");
     Serial.printf("Home Guardian Gateway v%s\n", FIRMWARE_VERSION);
-    Serial.printf("Gateway UID: %s\n", GATEWAY_UID);
     Serial.println("=============================\n");
 
-    // 1. 看门狗
     watchdog_init(8000);
+    pinMode(FACTORY_RESET_PIN, INPUT_PULLUP);
 
-    // 2. WiFi
-    wifi.begin(WIFI_SSID, WIFI_PASSWORD);
+    store.begin();
+    Serial.printf("[Main] 网关 UID: %s\n", store.gatewayUid().c_str());
 
-    // 3. 注册传感器（每个传感器带独立 UID）
-    #if SENSOR_DHT11_ENABLED
-    {
-        static SensorDHT11 dht(DHT11_PIN, SENSOR_DHT11_UID);
-        sensors.registerSensor(&dht);
-    }
-    #endif
-    #if SENSOR_SOUND_ENABLED
-    {
-        static SensorSound sound(SOUND_SENSOR_PIN, SENSOR_SOUND_UID);
-        sensors.registerSensor(&sound);
-    }
-    #endif
-    sensors.beginAll();
-    Serial.printf("[Main] 已注册 %d 个传感器\n", sensors.count());
-
-    // 4. 指令
     commands.registerAction("ping",     handlePing);
     commands.registerAction("get_info", handleGetInfo);
     commands.registerAction("reboot",   handleReboot);
 
-    // 5. MQTT（用网关 UID 认证）
-    mqtt.begin(MQTT_HOST, MQTT_PORT, GATEWAY_UID, MQTT_PASSWORD);
-    mqtt.onCommand([](const char* payload, unsigned int len) {
-        commands.handle(payload, len, mqtt);
-    });
+    registerSensors();
 
-    Serial.println("[Main] 初始化完成\n");
+    if (!store.hasWifi()) {
+        mode = MODE_PROVISION;
+        provisioning.begin(&store);
+        Serial.println("[Main] 未配置 WiFi → 进入配网模式");
+    } else {
+        mode = MODE_NORMAL;
+        startNormal();
+        Serial.println("[Main] 初始化完成\n");
+    }
 }
 
 void loop() {
     watchdog_feed();
+    checkFactoryReset();
+
+    // ── 配网模式：只跑门户 ──
+    if (mode == MODE_PROVISION) {
+        provisioning.loop();
+        if (provisioning.isDone()) {
+            Serial.println("[Main] 配网信息已保存，重启进入注册\n");
+            delay(1000);
+            ESP.restart();
+        }
+        return;
+    }
+
+    // ── 正常模式 ──
     wifi.loop();
     mqtt.loop();
 
@@ -136,7 +243,6 @@ void loop() {
                 mqtt.publishSensorTelemetry(s->uid(), buffer);
                 Serial.printf("[%s] → %s\n", s->uid(), buffer);
             } else {
-                // 传感器读取失败 → 标记该传感器离线
                 mqtt.publishSensorState(s->uid(), false);
                 Serial.printf("[%s] 读取失败，标记离线\n", s->uid());
             }

--- a/firmware/src/mqtt_manager.cpp
+++ b/firmware/src/mqtt_manager.cpp
@@ -6,7 +6,7 @@ MqttManager* MqttManager::_instance = nullptr;
 bool MqttManager::begin(const char* host, uint16_t port,
                         const char* gatewayUid, const char* password) {
     _instance = this;
-    _host = host;
+    _host = host;              // String 拷贝
     _port = port;
     _gatewayUid = gatewayUid;
     _password = password;
@@ -17,7 +17,7 @@ bool MqttManager::begin(const char* host, uint16_t port,
     snprintf(_gatewayCommandReply, sizeof(_gatewayCommandReply), "home/upstream/%s/command/reply",  gatewayUid);
 
     _mqtt.setClient(_wifiClient);
-    _mqtt.setServer(host, port);
+    _mqtt.setServer(_host.c_str(), port);
     _mqtt.setCallback(_mqttCallback);
     _mqtt.setBufferSize(512);
 
@@ -26,12 +26,12 @@ bool MqttManager::begin(const char* host, uint16_t port,
 }
 
 void MqttManager::connect() {
-    Serial.printf("[MQTT] 连接 %s:%d (gateway=%s)...\n", _host, _port, _gatewayUid);
+    Serial.printf("[MQTT] 连接 %s:%d (gateway=%s)...\n", _host.c_str(), _port, _gatewayUid.c_str());
 
     bool ok = _mqtt.connect(
-        _gatewayUid,              // client id
-        _gatewayUid,              // username (网关的 device_uid)
-        _password,                // password
+        _gatewayUid.c_str(),      // client id
+        _gatewayUid.c_str(),      // username (网关的 device_uid)
+        _password.c_str(),        // password
         _gatewayStateTopic,       // will topic (网关的 state)
         1,                        // will QoS
         false,                    // will retain

--- a/firmware/src/provisioning.cpp
+++ b/firmware/src/provisioning.cpp
@@ -1,0 +1,106 @@
+#include "provisioning.h"
+#include <WiFi.h>
+#include "config.h"
+
+static const byte DNS_PORT = 53;
+
+void Provisioning::begin(ConfigStore* store) {
+    _store = store;
+    _done = false;
+
+    // 热点名带 MAC 后缀，便于区分多台设备
+    String uid = ConfigStore::deviceUid();          // esp32-aabbcc
+    String ap = "HG-Setup-" + uid.substring(uid.length() - 4);
+
+    WiFi.mode(WIFI_AP);
+    WiFi.softAP(ap.c_str());
+    IPAddress ip = WiFi.softAPIP();  // 默认 192.168.4.1
+    Serial.printf("[配网] 热点已开: %s  →  http://%s\n", ap.c_str(), ip.toString().c_str());
+
+    // captive portal：所有域名解析到本机
+    _dns.start(DNS_PORT, "*", ip);
+
+    _server.on("/", HTTP_GET, [this]() { handleRoot(); });
+    _server.on("/scan", HTTP_GET, [this]() { handleScan(); });
+    _server.on("/provision", HTTP_POST, [this]() { handleProvision(); });
+    // 常见系统探测路径 → 重定向到配网页，触发弹窗
+    _server.onNotFound([this]() {
+        _server.sendHeader("Location", "http://192.168.4.1/", true);
+        _server.send(302, "text/plain", "");
+    });
+    _server.begin();
+}
+
+void Provisioning::loop() {
+    _dns.processNextRequest();
+    _server.handleClient();
+}
+
+void Provisioning::handleRoot() {
+    String surl = _store->serverUrl();
+#ifdef DEFAULT_SERVER_URL
+    if (surl.length() == 0) surl = DEFAULT_SERVER_URL;
+#endif
+
+    String html =
+        "<!doctype html><html><head><meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+        "<title>Home Guardian 配网</title>"
+        "<style>body{font-family:sans-serif;max-width:420px;margin:0 auto;padding:20px;background:#f5f6f8}"
+        "h2{text-align:center}label{display:block;margin:12px 0 4px;font-size:14px;color:#333}"
+        "input,select{width:100%;box-sizing:border-box;padding:10px;border:1px solid #ccc;border-radius:8px;font-size:15px}"
+        "button{width:100%;margin-top:18px;padding:12px;border:0;border-radius:8px;background:#3b82f6;color:#fff;font-size:16px}"
+        ".hint{font-size:12px;color:#888;margin-top:14px;line-height:1.6}</style></head><body>"
+        "<h2>设备配网</h2>"
+        "<form method='POST' action='/provision'>"
+        "<label>WiFi 名称</label><select name='ssid' id='ssid'><option>加载中...</option></select>"
+        "<label>WiFi 密码</label><input type='password' name='pass' placeholder='家里 WiFi 密码'>"
+        "<label>配对码</label><input name='code' placeholder='App 上生成的配对码' autocapitalize='characters'>"
+        "<label>平台地址</label><input name='server' value='" + surl + "' placeholder='https://your-server'>"
+        "<button type='submit'>连接并配网</button>"
+        "</form>"
+        "<div class='hint'>在 Home Guardian App「添加设备」生成配对码后粘贴到上面，填入家里 WiFi 即可。</div>"
+        "<script>fetch('/scan').then(r=>r.json()).then(l=>{var s=document.getElementById('ssid');"
+        "s.innerHTML='';(l||[]).forEach(function(n){var o=document.createElement('option');o.value=n;o.text=n;s.add(o);});"
+        "if(!l||!l.length){var o=document.createElement('option');o.text='(未扫描到，手动输入)';s.add(o);}});</script>"
+        "</body></html>";
+
+    _server.send(200, "text/html", html);
+}
+
+void Provisioning::handleScan() {
+    int n = WiFi.scanNetworks();
+    String json = "[";
+    for (int i = 0; i < n; i++) {
+        if (i) json += ",";
+        String ssid = WiFi.SSID(i);
+        ssid.replace("\"", "\\\"");
+        json += "\"" + ssid + "\"";
+    }
+    json += "]";
+    WiFi.scanDelete();
+    _server.send(200, "application/json", json);
+}
+
+void Provisioning::handleProvision() {
+    String ssid   = _server.arg("ssid");
+    String pass   = _server.arg("pass");
+    String code   = _server.arg("code");
+    String server = _server.arg("server");
+
+    if (ssid.length() == 0) {
+        _server.send(400, "text/html", "<h3>请选择 WiFi</h3>");
+        return;
+    }
+    code.trim();
+    server.trim();
+
+    _store->saveProvisioning(ssid, pass, server, code);
+    Serial.printf("[配网] 已保存: ssid=%s server=%s code=%s\n", ssid.c_str(), server.c_str(), code.c_str());
+
+    _server.send(200, "text/html",
+        "<!doctype html><meta charset='utf-8'><body style='font-family:sans-serif;text-align:center;padding:40px'>"
+        "<h2>配网中…</h2><p>设备正在连接 WiFi 并注册，请回到 App 等待上线。</p></body>");
+
+    _done = true;  // main 会在 loop 里看到并重启
+}

--- a/firmware/src/registration.cpp
+++ b/firmware/src/registration.cpp
@@ -1,0 +1,90 @@
+#include "registration.h"
+#include <HTTPClient.h>
+#include <WiFiClient.h>
+#include <WiFiClientSecure.h>
+#include <ArduinoJson.h>
+
+bool Registration::run(ConfigStore& store, SensorRegistry& sensors, const char* fw) {
+    String url = store.serverUrl();
+    if (url.length() == 0) {
+        Serial.println("[注册] 未配置平台地址 server_url");
+        return false;
+    }
+    String endpoint = url + "/api/provisioning/register";
+
+    // ── 构建请求体：网关 + 子传感器自述
+    JsonDocument doc;
+    doc["provision_code"] = store.provisionCode();
+    JsonObject gw = doc["gateway"].to<JsonObject>();
+    gw["device_uid"]       = store.gatewayUid();
+    gw["name"]             = "Home Guardian 网关";
+    gw["model"]            = "esp32";
+    gw["firmware_version"] = fw;
+
+    JsonArray arr = doc["sensors"].to<JsonArray>();
+    for (uint8_t i = 0; i < sensors.count(); i++) {
+        ISensor* s = sensors.get(i);
+        if (!s) continue;
+        JsonObject o = arr.add<JsonObject>();
+        o["device_uid"] = s->uid();   // 与后续遥测发布使用的 uid 一致
+        o["name"]       = s->name();
+        o["type"]       = "sensor";
+    }
+
+    String body;
+    serializeJson(doc, body);
+
+    // ── 发送（https 用 WiFiClientSecure；自签证书开发期 setInsecure）
+    bool https = url.startsWith("https");
+    HTTPClient http;
+    WiFiClientSecure secure;
+    WiFiClient plain;
+    bool ok;
+    if (https) {
+        secure.setInsecure();  // 生产可换成 setCACert() 固定证书
+        ok = http.begin(secure, endpoint);
+    } else {
+        ok = http.begin(plain, endpoint);
+    }
+    if (!ok) {
+        Serial.println("[注册] HTTP begin 失败");
+        return false;
+    }
+    http.addHeader("Content-Type", "application/json");
+    http.setTimeout(10000);
+
+    int status = http.POST(body);
+    String resp = http.getString();
+    http.end();
+
+    Serial.printf("[注册] POST %s -> %d\n", endpoint.c_str(), status);
+    Serial.println(resp);
+
+    if (status != 200 && status != 201) {
+        return false;
+    }
+
+    JsonDocument rd;
+    if (deserializeJson(rd, resp)) {
+        Serial.println("[注册] 响应 JSON 解析失败");
+        return false;
+    }
+    if ((int)(rd["code"] | -1) != 0) {
+        return false;
+    }
+
+    JsonObject mqtt = rd["data"]["mqtt"];
+    String host    = mqtt["host"]     | "";
+    uint16_t port  = mqtt["port"]     | 1883;
+    String user    = mqtt["username"] | "";
+    String pass    = mqtt["password"] | "";
+
+    if (user.length() == 0 || pass.length() == 0) {
+        Serial.println("[注册] 响应缺少 MQTT 凭证");
+        return false;
+    }
+
+    store.saveMqtt(host, port, user, pass);
+    Serial.printf("[注册] 成功: mqtt=%s@%s:%u\n", user.c_str(), host.c_str(), port);
+    return true;
+}

--- a/firmware/src/wifi_manager.cpp
+++ b/firmware/src/wifi_manager.cpp
@@ -3,12 +3,12 @@
 #include <Arduino.h>
 
 void WifiManager::begin(const char* ssid, const char* password) {
-    _ssid = ssid;
+    _ssid = ssid;          // String 拷贝
     _password = password;
 
     WiFi.mode(WIFI_STA);
     WiFi.setAutoReconnect(true);
-    WiFi.begin(ssid, password);
+    WiFi.begin(_ssid.c_str(), _password.c_str());
 
     Serial.printf("[WiFi] 正在连接 %s", ssid);
 


### PR DESCRIPTION
把网络/身份凭证从编译期 config.h 搬到运行期(NVS)，支撑自助配网：
- config_store: Preferences(NVS) 存 wifi/server/配对码/mqtt凭证/网关uid； MAC 派生稳定 device_uid；兼容旧的 config.h 手动烧录(自动播种)
- provisioning: SoftAP(HG-Setup-xxxx) + DNS captive portal + 自托管配网页 (WiFi 扫描/填写 + 粘贴配对码 + 平台地址)
- registration: 连网后 POST /api/provisioning/register(网关+子传感器自述)， 拿回 MQTT 凭证存 NVS(https 用 WiFiClientSecure)
- main: 启动状态机(无WiFi→配网 / 有WiFi无MQTT→注册 / 齐全→运行)+ 长按 BOOT 键 5s 恢复出厂
- wifi/mqtt manager: 凭证改存 String 拷贝(修运行期裸指针生命周期)
- config.example.h: 拆分编译期(硬件/版本/DEFAULT_SERVER_URL)与运行期(凭证)

未在本环境编译(无 ESP32 工具链)；依赖均为 ESP32 core 内置(Preferences/ WebServer/DNSServer/HTTPClient/WiFiClientSecure) + 已有 ArduinoJson。

<!-- 感谢贡献！请填写以下信息，便于评审。 -->

## 这个 PR 做了什么

<!-- 简述动机与改动内容 -->

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构 / 性能
- [ ] 文档
- [ ] 构建 / CI / 其他

## 自检清单

- [ ] 后端：`php -l` 通过，`composer test`（PHPUnit）通过
- [ ] 移动端（如涉及）：`npx tsc --noEmit` 与 `npm run build` 通过
- [ ] 已为新增/变更逻辑补充或更新测试（如适用）
- [ ] 已更新相关文档（README / 蓝图等）

## 部署影响

<!-- 是否需要：新数据库迁移 / 新环境变量 / 新进程 / 重新构建移动端？没有则写「无」 -->

## 关联 Issue

<!-- Closes #123 -->
