### PR TITLE
chore(deploy): deploy-h5.sh 部署时自动执行数据库迁移

### DIFF
--- a/scripts/deploy-h5.sh
+++ b/scripts/deploy-h5.sh
@@ -45,7 +45,16 @@ docker compose -f "$COMPOSE_FILE" build webman
 log "重建容器…"
 docker compose -f "$COMPOSE_FILE" up -d --force-recreate webman nginx
 
-# ── 3. 健康检查 ───────────────────────────────────────────────
+# ── 3. 数据库迁移（后端有新迁移时自动补跑）────────────────────
+log "执行数据库迁移…"
+# 等 webman 起来再迁移
+for i in $(seq 1 15); do
+  docker compose -f "$COMPOSE_FILE" exec -T webman php -r 'exit(0);' >/dev/null 2>&1 && break
+  sleep 2
+done
+docker compose -f "$COMPOSE_FILE" exec -T webman php webman migrate:run || die "数据库迁移失败"
+
+# ── 4. 健康检查 ───────────────────────────────────────────────
 log "等待服务就绪…"
 ok=0
 for i in $(seq 1 20); do


### PR DESCRIPTION
避免后端带新迁移时漏跑（如 user_push_devices 曾导致 relation does not exist）。

<!-- 感谢贡献！请填写以下信息，便于评审。 -->

## 这个 PR 做了什么

<!-- 简述动机与改动内容 -->

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构 / 性能
- [ ] 文档
- [ ] 构建 / CI / 其他

## 自检清单

- [ ] 后端：`php -l` 通过，`composer test`（PHPUnit）通过
- [ ] 移动端（如涉及）：`npx tsc --noEmit` 与 `npm run build` 通过
- [ ] 已为新增/变更逻辑补充或更新测试（如适用）
- [ ] 已更新相关文档（README / 蓝图等）

## 部署影响

<!-- 是否需要：新数据库迁移 / 新环境变量 / 新进程 / 重新构建移动端？没有则写「无」 -->

## 关联 Issue

<!-- Closes #123 -->
