### PR TITLE
feat(security): 公开接口限流 + 屏蔽 MQTT 回调外网 + 网关 ACL 修正

### DIFF
--- a/app/middleware/RateLimitMiddleware.php
+++ b/app/middleware/RateLimitMiddleware.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Home Guardian - 简单限流中间件（滑动固定窗口）
+ *
+ * 用于保护公开接口（登录 / 注册 / 配网注册）免受爆破与刷量。
+ * 以 "客户端 IP + 路由标识" 为 key，在 Redis 里按固定时间窗计数，超限返回 429。
+ *
+ * 用法：
+ *   ->middleware([new RateLimitMiddleware('login', 10, 60)])  // 60s 内最多 10 次
+ *
+ * Redis 不可用时放行（fail-open）：宁可短暂失去限流，也不因缓存故障锁死登录。
+ */
+
+namespace app\middleware;
+
+use Webman\Http\Request;
+use Webman\Http\Response;
+use Webman\MiddlewareInterface;
+use support\Redis;
+use support\Log;
+
+class RateLimitMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private readonly string $bucket,   // 路由标识，如 'login'
+        private readonly int $limit = 20,  // 窗口内最大请求数
+        private readonly int $window = 60  // 窗口秒数
+    ) {
+    }
+
+    public function process(Request $request, callable $handler): Response
+    {
+        $ip = $this->clientIp($request);
+        $key = "ratelimit:{$this->bucket}:{$ip}";
+
+        try {
+            $redis = Redis::connection('default');
+            $count = $redis->incr($key);
+            if ($count === 1) {
+                $redis->expire($key, $this->window);
+            }
+            if ($count > $this->limit) {
+                $ttl = $redis->ttl($key);
+                return api_error("请求过于频繁，请 {$ttl} 秒后再试", 429, 1006);
+            }
+        } catch (\Throwable $e) {
+            // 缓存故障不阻断业务
+            Log::warning("限流失效（Redis 异常）: {$e->getMessage()}");
+        }
+
+        return $handler($request);
+    }
+
+    /**
+     * 取真实客户端 IP（信任反代传入的 X-Forwarded-For 首段）
+     */
+    private function clientIp(Request $request): string
+    {
+        $xff = $request->header('x-forwarded-for', '');
+        if ($xff !== '') {
+            return trim(explode(',', $xff)[0]);
+        }
+        return $request->getRealIp();
+    }
+}

--- a/app/service/DeviceService.php
+++ b/app/service/DeviceService.php
@@ -250,8 +250,23 @@ class DeviceService
         }
 
         if ($action === 'subscribe') {
-            // 设备只能订阅自己的 downstream 主题
-            return str_starts_with($topic, "home/downstream/{$uid}/");
+            // 设备可订阅自己的 downstream 主题
+            if (str_starts_with($topic, "home/downstream/{$uid}/")) {
+                return true;
+            }
+
+            // 网关代其下子设备接收指令：允许订阅子设备的 downstream
+            // （子设备不直连 MQTT，指令经网关下发；缺此项子执行器收不到指令）
+            if ($device->type === 'gateway') {
+                $sensorUids = Device::where('gateway_uid', $uid)->pluck('device_uid')->toArray();
+                foreach ($sensorUids as $sensorUid) {
+                    if (str_starts_with($topic, "home/downstream/{$sensorUid}/")) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         return false;

--- a/config/route.php
+++ b/config/route.php
@@ -163,9 +163,12 @@ Route::get('/api/health', function () {
 |--------------------------------------------------------------------------
 */
 Route::group('/api/auth', function () {
-    Route::post('/login', [app\controller\AuthController::class, 'login']);
-    Route::post('/refresh', [app\controller\AuthController::class, 'refresh']);
-    Route::post('/register', [app\controller\AuthController::class, 'register']);
+    Route::post('/login', [app\controller\AuthController::class, 'login'])
+        ->middleware([new app\middleware\RateLimitMiddleware('login', 10, 60)]);
+    Route::post('/refresh', [app\controller\AuthController::class, 'refresh'])
+        ->middleware([new app\middleware\RateLimitMiddleware('refresh', 30, 60)]);
+    Route::post('/register', [app\controller\AuthController::class, 'register'])
+        ->middleware([new app\middleware\RateLimitMiddleware('register', 5, 60)]);
 });
 
 /*
@@ -184,7 +187,8 @@ Route::group('/api/mqtt', function () {
 |--------------------------------------------------------------------------
 */
 Route::group('/api/provisioning', function () {
-    Route::post('/register', [app\controller\ProvisioningController::class, 'register']);
+    Route::post('/register', [app\controller\ProvisioningController::class, 'register'])
+        ->middleware([new app\middleware\RateLimitMiddleware('provision_register', 20, 60)]);
 });
 
 /*

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -30,6 +30,13 @@ server {
         proxy_send_timeout 60s;
     }
 
+    # MQTT 认证/ACL 回调：仅供 EMQX 在容器内网直连 webman:8787 调用，
+    # 绝不对外暴露（否则可被当作设备凭证爆破器）。放在 /api/ 之前优先匹配。
+    location ^~ /api/mqtt/ {
+        deny all;
+        return 403;
+    }
+
     # REST API → 后端 Webman
     location /api/ {
         proxy_pass http://webman_http;


### PR DESCRIPTION
#1 RateLimitMiddleware(Redis 固定窗,fail-open)挂 login(10/60)/register(5/60)
   /refresh(30/60)/provisioning register(20/60)，返回 429
#2 nginx deny /api/mqtt/：EMQX 认证/ACL 回调只走容器内网，杜绝当凭证爆破器 #4 修正 checkMqttAcl：网关可订阅其子设备 downstream（否则子执行器收不到指令），
   同时维持"设备只能收发自身 topic"的隔离

<!-- 感谢贡献！请填写以下信息，便于评审。 -->

## 这个 PR 做了什么

<!-- 简述动机与改动内容 -->

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构 / 性能
- [ ] 文档
- [ ] 构建 / CI / 其他

## 自检清单

- [ ] 后端：`php -l` 通过，`composer test`（PHPUnit）通过
- [ ] 移动端（如涉及）：`npx tsc --noEmit` 与 `npm run build` 通过
- [ ] 已为新增/变更逻辑补充或更新测试（如适用）
- [ ] 已更新相关文档（README / 蓝图等）

## 部署影响

<!-- 是否需要：新数据库迁移 / 新环境变量 / 新进程 / 重新构建移动端？没有则写「无」 -->

## 关联 Issue

<!-- Closes #123 -->
