### PR TITLE
feat(ac): ESP32 红外空调控制（海信等国产成品机通用）

### DIFF
--- a/docs/guide/ac-ir-control.md
+++ b/docs/guide/ac-ir-control.md
@@ -1,0 +1,129 @@
+# 用 ESP32 红外控制空调（海信/美的/格力/海尔通用）
+
+国产成品空调（海信等）是"云锁定"的——它的 WiFi 模块只连厂商云，没法直连你的 MQTT。
+本方案绕开这层，用一个 **ESP32 + 红外发射管**假装成空调遥控器：Home Guardian 把
+"开机/制冷/26℃/自动风"这样的完整状态经 MQTT 下发给 ESP32，ESP32 合成对应品牌的
+红外帧发射出去。
+
+- ✅ 完全复用现有 MQTT 架构，本地控制，无厂商云依赖
+- ✅ 不挑品牌——换空调只改一个协议常量
+- ⚠️ 红外是**开环**（只发不收）：发完不保证空调真执行了，也读不到空调真实温度。
+  强烈建议同一块 ESP32 再接一个 DHT11，用真实室温做闭环展示与自动化。
+
+---
+
+## 一、准备硬件
+
+| 器件 | 说明 |
+|---|---|
+| ESP32 开发板 | 任意 esp32dev |
+| 红外发射管（940nm） | 淘宝几毛钱一个 |
+| NPN 三极管（如 S8050）+ 100Ω/1kΩ 电阻 | **必须**，勿把红外管直连 GPIO——电流不够射程只有几厘米 |
+| DHT11/DHT22（可选，强烈建议） | 做闭环用，测真实室温 |
+
+**红外发射驱动电路**（射程可达数米）：
+
+```
+ESP32 GPIO25 ──[1kΩ]── B (三极管基极)
+3V3 ──[100Ω]── 红外管(+) ── 红外管(-) ── C (集电极)
+                                          E (发射极) ── GND
+```
+
+把红外管**对准空调的接收窗**（一般在室内机显示屏附近）。
+
+---
+
+## 二、识别你的空调红外协议
+
+IRremoteESP8266 内置 50+ 品牌协议。先搞清楚你这台是哪种：
+
+1. 用 Arduino/PlatformIO 烧录库自带例程 **`IRrecvDumpV3`**（接一个红外**接收**头，如 VS1838B 到 GPIO14）。
+2. 拿实体遥控对着接收头按几个键，看串口输出的 `Protocol` 行，例如：
+
+   ```
+   Protocol  : COOLIX
+   ```
+
+3. 常见结果：海信多为 `COOLIX` 或 `HITACHI_AC` 系；美的 `MIDEA`；格力 `GREE`；海尔 `HAIER_AC`；TCL `TCL112AC`。
+
+> 没有红外接收头也行——先按下一步用默认 `COOLIX` 试，不生效再回来识别。
+
+---
+
+## 三、烧录固件
+
+固件已内置红外空调执行器，只需在 `firmware/include/config.h`（从 `config.example.h` 复制）里打开开关：
+
+```cpp
+#define AC_IR_ENABLED   1                        // 启用
+#define IR_LED_PIN      25                       // 你接红外管的 GPIO
+#define AC_PROTOCOL     decode_type_t::COOLIX    // 换成上一步识别到的协议
+```
+
+`platformio.ini` 已包含 `crankyoldgit/IRremoteESP8266` 依赖，直接编译烧录：
+
+```bash
+cd firmware && pio run -t upload && pio device monitor
+```
+
+WiFi/MQTT 凭证走两种方式（与传感器一致）：
+- **自助配网**（推荐）：保持 `WIFI_SSID="YourWiFi"` 占位值，开机进 SoftAP，在 App 生成配对码配网自注册；
+- **手动烧录**：直接把真实 WiFi + 后台建好的设备 uid/密码填进 `config.h`。
+
+---
+
+## 四、在后台/App 里把它变成"空调"
+
+设备上线后，还要给它套上"空调"能力（这决定 App 上显示什么控件）：
+
+1. 进**管理后台**或 **App → 设备管理**，找到这台设备；
+2. 编辑设备，**能力模板**选内置的 **「空调」**（数据库已预置，`device_category=ac`、`control_mode=merge`）；
+3. 建议把**设备类型**设成 `ac`（不要留 `gateway`，否则首页会按网关隐藏它）；
+4. 保存。
+
+现在 App 设备详情页会出现：**电源开关 · 模式(制冷/制热/除湿/送风) · 温度(−/＋ 步进) · 风速 · 扫风**。关机时其余控件自动置灰。
+
+---
+
+## 五、验证
+
+1. App 里打开这台空调 → 点"电源"；
+2. 看 ESP32 串口应打印 `[CMD] 收到指令: action=set_state` 和红外发射日志；
+3. 空调响一声、执行 → 成功。
+
+工作链路：
+
+```
+App 改任一项 → 后端 ActuatorService(merge) 合并出完整状态
+   → MQTT home/downstream/{uid}/command/set {action:set_state, params:{power,mode,temp,fan,swing}}
+   → ESP32 IRac 合成红外帧发射 → 空调
+   → ESP32 回 command/reply + 上报 state/post（多端同步显示）
+```
+
+**若空调没反应**：多半是协议不对（串口会打印"协议 X 不受 IRac 支持"或空调无响应）。回到第二步重新识别 `AC_PROTOCOL`；仍不行则该机型需走"原始码学习"（见下）。
+
+---
+
+## 六、闭环（强烈建议）
+
+红外发完不知道空调真实状态。给这块 ESP32 同时开启 DHT11（`SENSOR_DHT11_ENABLED 1`），
+它会作为子传感器上报真实室温湿度。这样你可以：
+
+- App 上看到**空调控制卡 + 真实室温**并排；
+- 建**自动化**："室温 > 28℃ → 下发 空调 制冷 24℃"；建**告警规则**："室温持续 5 分钟 > 32℃ 报警"（配合刚上线的双向迟滞防抖，抖动不会刷屏）。
+
+---
+
+## 七、协议不支持时的兜底：原始码学习
+
+极少数机型 IRac 不支持。此时用"录制—回放"：对每个按键（开、关、16℃…30℃、各模式）
+用 `IRrecvDumpV3` 抓原始 `rawData[]`，存进固件按 `set_state` 的目标状态回放对应码。
+这条路万能但繁琐（每个组合一条码），需要时再单独做一版学习型固件。
+
+---
+
+## 参考
+
+- IRremoteESP8266：<https://github.com/crankyoldgit/IRremoteESP8266>（`SupportedProtocols.md` 有完整协议清单）
+- 能力模板定义：`database/php-migrations/2026_06_18_000001_create_capability_templates_table.php`
+- 指令流转：`app/service/ActuatorService.php`、固件 `firmware/src/ac_ir.cpp`

--- a/firmware/include/ac_ir.h
+++ b/firmware/include/ac_ir.h
@@ -1,0 +1,36 @@
+#ifndef AC_IR_H
+#define AC_IR_H
+
+#include <ArduinoJson.h>
+#include <IRremoteESP8266.h>
+#include <IRac.h>
+
+/**
+ * 红外空调执行器
+ *
+ * 用 IRremoteESP8266 的 IRac 抽象层，把一份通用状态（电源/模式/温度/风速/扫风）
+ * 合成为具体品牌的红外帧发射出去。品牌差异由 IRac 内部按 protocol 处理，
+ * 因此本类与品牌无关——换空调只需改 config.h 里的 AC_PROTOCOL。
+ *
+ * 与后端约定（merge 模式）：每次 set_state 携带全量参数，缺省的沿用上次状态。
+ */
+class AcIr {
+public:
+    AcIr(uint16_t irLedPin, decode_type_t protocol);
+
+    void begin();
+
+    // 合并 params 到当前状态、发射红外；把当前完整状态写回 outState。
+    // 返回 IRac 是否支持该协议并成功发送。
+    bool apply(const JsonObject& params, JsonObject& outState);
+
+    // 把当前状态序列化为后端约定的字段（power/mode/temp/fan/swing）
+    void fillState(JsonObject& outState) const;
+
+private:
+    IRac _ac;
+    decode_type_t _protocol;
+    stdAc::state_t _state;
+};
+
+#endif

--- a/firmware/include/config.example.h
+++ b/firmware/include/config.example.h
@@ -31,6 +31,21 @@
 // #define SENSOR_DHT11_UID    "sensor-temp-01"
 // #define SENSOR_SOUND_UID    "sensor-sound-01"
 
+// ─── 红外空调执行器（可选）──────────────────────────
+//  接一个红外发射管到 IR_LED_PIN，即可把本设备变成"空调万能遥控器"：
+//  收到后台/App 下发的 set_state 指令（全量 电源/模式/温度/风速/扫风）后，
+//  用 IRremoteESP8266 合成对应品牌的红外帧发射出去。完整接入见
+//  docs/guide/ac-ir-control.md。
+//
+//  ⚠️ 红外是开环（只发不收）——发完不保证空调真的执行了。建议本机同时接
+//     DHT11（上面的传感器模块），用真实室温做闭环展示与自动化。
+#define AC_IR_ENABLED          0                     // 置 1 启用红外空调执行器
+#define IR_LED_PIN             25                    // 红外发射管 GPIO（需经三极管驱动，勿直连）
+//  你的空调红外协议：先用库自带的 IRrecvDumpV3 例程对着实体遥控识别 Protocol，
+//  再填到这里。常见：COOLIX / HITACHI_AC / HAIER_AC / MIDEA / GREE / TCL112AC …
+//  海信机型多数落在 COOLIX 或 HITACHI 系；识别不出就走原始码学习（见文档）。
+#define AC_PROTOCOL            decode_type_t::COOLIX
+
 // =====================================================================
 //  运行期配置（WiFi / MQTT 身份）
 // =====================================================================

--- a/firmware/include/mqtt_manager.h
+++ b/firmware/include/mqtt_manager.h
@@ -17,6 +17,10 @@ public:
     // 网关自身状态
     bool publishGatewayState(bool online);
 
+    // 网关级完整状态上报（执行器用）：发布到 home/upstream/{uid}/state/post，
+    // 后端 state 字段落库并推 WS（reported=true）。json 形如 {"status":"online","state":{...}}
+    bool publishGatewayStateJson(const char* json);
+
     // 传感器级发布（用传感器自己的 device_uid 构建主题）
     bool publishSensorTelemetry(const char* sensorUid, const char* json);
     bool publishSensorState(const char* sensorUid, bool online);

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -8,6 +8,7 @@ lib_deps =
     adafruit/DHT sensor library@^1.4.6
     adafruit/Adafruit Unified Sensor@^1.1.14
     bblanchon/ArduinoJson@^7.0
+    crankyoldgit/IRremoteESP8266@^2.8.6
 build_flags =
     -DCORE_DEBUG_LEVEL=3
     -DMQTT_MAX_PACKET_SIZE=512

--- a/firmware/src/ac_ir.cpp
+++ b/firmware/src/ac_ir.cpp
@@ -1,0 +1,89 @@
+#include "ac_ir.h"
+#include <Arduino.h>
+#include <string.h>
+#include <IRutils.h>   // typeToString()
+
+// ─── 模式字符串 ⇄ IRac 枚举 ─────────────────────────────
+static stdAc::opmode_t parseMode(const char* m) {
+    if (!strcmp(m, "cool")) return stdAc::opmode_t::kCool;
+    if (!strcmp(m, "heat")) return stdAc::opmode_t::kHeat;
+    if (!strcmp(m, "dry"))  return stdAc::opmode_t::kDry;
+    if (!strcmp(m, "fan"))  return stdAc::opmode_t::kFan;
+    return stdAc::opmode_t::kAuto;
+}
+static const char* modeStr(stdAc::opmode_t m) {
+    switch (m) {
+        case stdAc::opmode_t::kCool: return "cool";
+        case stdAc::opmode_t::kHeat: return "heat";
+        case stdAc::opmode_t::kDry:  return "dry";
+        case stdAc::opmode_t::kFan:  return "fan";
+        default:                     return "auto";
+    }
+}
+
+// ─── 风速字符串 ⇄ IRac 枚举 ─────────────────────────────
+static stdAc::fanspeed_t parseFan(const char* f) {
+    if (!strcmp(f, "low"))  return stdAc::fanspeed_t::kLow;
+    if (!strcmp(f, "mid"))  return stdAc::fanspeed_t::kMedium;
+    if (!strcmp(f, "high")) return stdAc::fanspeed_t::kHigh;
+    return stdAc::fanspeed_t::kAuto;
+}
+static const char* fanStr(stdAc::fanspeed_t f) {
+    switch (f) {
+        case stdAc::fanspeed_t::kLow:    return "low";
+        case stdAc::fanspeed_t::kMedium: return "mid";
+        case stdAc::fanspeed_t::kHigh:   return "high";
+        default:                         return "auto";
+    }
+}
+
+AcIr::AcIr(uint16_t irLedPin, decode_type_t protocol)
+    : _ac(irLedPin), _protocol(protocol) {}
+
+void AcIr::begin() {
+    // 初始默认状态：与后端"空调"能力模板的 default 对齐（关机 / 制冷 / 26℃ / 自动风）
+    _state.protocol = _protocol;
+    _state.model    = 1;
+    _state.power    = false;
+    _state.mode     = stdAc::opmode_t::kCool;
+    _state.degrees  = 26;
+    _state.celsius  = true;
+    _state.fanspeed = stdAc::fanspeed_t::kAuto;
+    _state.swingv   = stdAc::swingv_t::kOff;
+    _state.swingh   = stdAc::swingh_t::kOff;
+    _state.light    = true;
+    _state.beep     = false;
+    _state.econo    = false;
+    _state.filter   = false;
+    _state.turbo    = false;
+    _state.quiet    = false;
+    _state.clean    = false;
+    _state.sleep    = -1;   // -1 = 不设置
+    _state.clock    = -1;
+}
+
+bool AcIr::apply(const JsonObject& params, JsonObject& outState) {
+    // merge：只覆盖本次带来的字段，其余沿用当前状态
+    if (params["power"].is<bool>())        _state.power    = params["power"].as<bool>();
+    if (params["mode"].is<const char*>())  _state.mode     = parseMode(params["mode"].as<const char*>());
+    if (params["temp"].is<int>())          _state.degrees  = params["temp"].as<int>();
+    if (params["fan"].is<const char*>())   _state.fanspeed = parseFan(params["fan"].as<const char*>());
+    if (params["swing"].is<bool>())
+        _state.swingv = params["swing"].as<bool>() ? stdAc::swingv_t::kAuto : stdAc::swingv_t::kOff;
+
+    bool ok = _ac.sendAc(_state, nullptr);
+    if (!ok) {
+        Serial.printf("[AC-IR] 协议 %s 不受 IRac 支持，请改用原始码学习方案\n",
+                      typeToString(_protocol).c_str());
+    }
+    fillState(outState);
+    return ok;
+}
+
+void AcIr::fillState(JsonObject& outState) const {
+    outState["power"] = _state.power;
+    outState["mode"]  = modeStr(_state.mode);
+    outState["temp"]  = _state.degrees;
+    outState["fan"]   = fanStr(_state.fanspeed);
+    outState["swing"] = (_state.swingv != stdAc::swingv_t::kOff);
+}

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -28,6 +28,9 @@
 #if SENSOR_SOUND_ENABLED
 #include "sensor_sound.h"
 #endif
+#if AC_IR_ENABLED
+#include "ac_ir.h"
+#endif
 
 #ifndef FACTORY_RESET_PIN
 #define FACTORY_RESET_PIN 0   // BOOT 键
@@ -39,6 +42,9 @@ SensorRegistry sensors;
 CommandHandler commands;
 ConfigStore  store;
 Provisioning provisioning;
+#if AC_IR_ENABLED
+AcIr acIr(IR_LED_PIN, AC_PROTOCOL);
+#endif
 
 enum Mode { MODE_PROVISION, MODE_NORMAL };
 Mode mode = MODE_NORMAL;
@@ -69,6 +75,25 @@ bool handleReboot(const JsonObject& params, JsonObject& response) {
     ESP.restart();
     return true;
 }
+
+#if AC_IR_ENABLED
+// 红外空调：全量状态发射红外，回执带当前状态，并主动上报 state/post
+bool handleSetState(const JsonObject& params, JsonObject& response) {
+    bool ok = acIr.apply(params, response);
+
+    // 主动上报完整状态（reported=true），让多端展示与真实一致
+    if (mqtt.isConnected()) {
+        JsonDocument postDoc;
+        postDoc["status"] = "online";
+        JsonObject st = postDoc["state"].to<JsonObject>();
+        acIr.fillState(st);
+        char buf[256];
+        serializeJson(postDoc, buf, sizeof(buf));
+        mqtt.publishGatewayStateJson(buf);
+    }
+    return ok;
+}
+#endif
 
 // ─── 传感器注册（uid 优先用 config.h 指定，否则由网关 uid 派生）──────
 
@@ -178,6 +203,11 @@ void setup() {
     commands.registerAction("ping",     handlePing);
     commands.registerAction("get_info", handleGetInfo);
     commands.registerAction("reboot",   handleReboot);
+#if AC_IR_ENABLED
+    acIr.begin();
+    commands.registerAction("set_state", handleSetState);
+    Serial.printf("[Main] 红外空调执行器已启用 (IR_LED_PIN=%d)\n", IR_LED_PIN);
+#endif
 
     registerSensors();
 

--- a/firmware/src/mqtt_manager.cpp
+++ b/firmware/src/mqtt_manager.cpp
@@ -78,6 +78,10 @@ bool MqttManager::publishGatewayState(bool online) {
     return _mqtt.publish(_gatewayStateTopic, payload, true);
 }
 
+bool MqttManager::publishGatewayStateJson(const char* json) {
+    return _mqtt.publish(_gatewayStateTopic, json);
+}
+
 bool MqttManager::publishSensorTelemetry(const char* sensorUid, const char* json) {
     char topic[80];
     snprintf(topic, sizeof(topic), "home/upstream/%s/telemetry/post", sensorUid);

--- a/uniapp/src/api/types.ts
+++ b/uniapp/src/api/types.ts
@@ -31,6 +31,8 @@ export interface ControlPoint {
   default?: unknown;
   group?: string;
   order?: number;
+  // 依赖联动：仅当这些 state 字段全部等于给定值时该控件才可用（如空调开机后才可调温度）
+  depends_on?: Record<string, string | number | boolean>;
 }
 
 export interface Capability {

--- a/uniapp/src/pages/device/detail.vue
+++ b/uniapp/src/pages/device/detail.vue
@@ -46,7 +46,16 @@ async function load() {
   }
 }
 
+// 依赖联动：depends_on 的每个字段都需匹配当前 state，否则该控件禁用（灰）
+function disabled(ctrl: ControlPoint): boolean {
+  const dep = ctrl.depends_on;
+  if (!dep) return false;
+  const state = device.value?.state ?? {};
+  return Object.entries(dep).some(([k, v]) => state[k] !== v);
+}
+
 async function send(ctrl: ControlPoint, value: unknown) {
+  if (disabled(ctrl)) return;
   const prev = stateVal(ctrl);
   setLocal(ctrl, value);
   try {
@@ -65,6 +74,15 @@ function onSlider(ctrl: ControlPoint, e: { detail: { value: number } }) {
 }
 function onEnum(ctrl: ControlPoint, value: string | number) {
   send(ctrl, value);
+}
+// 步进器：在 [min,max] 内按 step 加减
+function onStep(ctrl: ControlPoint, dir: 1 | -1) {
+  const step = ctrl.step ?? 1;
+  const cur = Number(stateVal(ctrl) ?? ctrl.default ?? ctrl.min ?? 0);
+  let next = cur + dir * step;
+  if (ctrl.min != null) next = Math.max(ctrl.min, next);
+  if (ctrl.max != null) next = Math.min(ctrl.max, next);
+  if (next !== cur) send(ctrl, next);
 }
 
 function goTelemetry() {
@@ -133,7 +151,7 @@ onHide(() => { unsubs.forEach((u) => u()); unsubs = []; });
 
     <!-- 动态控制 -->
     <view v-if="controls.length" class="ctl-card">
-      <view v-for="ctrl in controls" :key="ctrl.key" class="ctl-row">
+      <view v-for="ctrl in controls" :key="ctrl.key" class="ctl-row" :class="{ disabled: disabled(ctrl) }">
         <view class="ctl-head">
           <text class="ctl-label">{{ ctrl.label }}</text>
           <text class="ctl-sub">{{ ctrl.command }} · 经网关下发</text>
@@ -156,6 +174,13 @@ onHide(() => { unsubs.forEach((u) => u()); unsubs = []; });
             :class="{ on: stateVal(ctrl) === op.value }"
             @tap="onEnum(ctrl, op.value)"
           >{{ op.label }}</view>
+        </view>
+
+        <!-- stepper → − 值 ＋ -->
+        <view v-else-if="ctrl.widget === 'stepper'" class="stepper">
+          <view class="step-btn" @tap="onStep(ctrl, -1)">−</view>
+          <text class="step-val">{{ Number(stateVal(ctrl) ?? ctrl.default ?? ctrl.min ?? 0) }}{{ ctrl.unit || '' }}</text>
+          <view class="step-btn" @tap="onStep(ctrl, 1)">＋</view>
         </view>
 
         <!-- slider -->
@@ -333,6 +358,38 @@ onHide(() => { unsubs.forEach((u) => u()); unsubs = []; });
 }
 .slider-wrap {
   margin-top: 10rpx;
+}
+.stepper {
+  display: flex;
+  align-items: center;
+  gap: 24rpx;
+  margin-top: 20rpx;
+}
+.step-btn {
+  width: 72rpx;
+  height: 72rpx;
+  line-height: 68rpx;
+  text-align: center;
+  border-radius: 50%;
+  background: $hg-accent-soft;
+  color: $hg-accent;
+  font-size: 44rpx;
+  font-weight: 700;
+}
+.step-val {
+  min-width: 120rpx;
+  text-align: center;
+  font-size: 40rpx;
+  font-weight: 700;
+  color: $hg-fg;
+}
+.ctl-row.disabled {
+  opacity: 0.4;
+}
+.ctl-row.disabled .sw,
+.ctl-row.disabled .seg-btn,
+.ctl-row.disabled .step-btn {
+  pointer-events: none;
 }
 .mini-btn {
   margin-top: 20rpx;


### PR DESCRIPTION
成品空调云锁定、无法直连 MQTT，改用 ESP32+红外发射管当"万能遥控器"：
后端经 merge 模式把全量状态(set_state)下发，ESP32 用 IRremoteESP8266 的 IRac 合成对应品牌红外帧发射。换品牌只改 config.h 的 AC_PROTOCOL。

固件：
- 新增 AcIr 模块（include/ac_ir.h + src/ac_ir.cpp），IRac 抽象层， 通用状态(电源/模式/温度/风速/扫风)⇄红外帧
- main.cpp 注册 set_state action，发射后回执带状态并主动上报 state/post
- mqtt_manager 增 publishGatewayStateJson（state/post 全量上报）
- config.example.h 增 AC_IR 配置块；platformio.ini 加 IRremoteESP8266

uniapp：
- detail.vue 补 stepper 控件渲染（空调温度用 stepper，此前会退化为只读 文本，无法调温）+ depends_on 关机置灰联动
- types.ts ControlPoint 增 depends_on

文档：
- docs/guide/ac-ir-control.md：接线→识别协议→烧录→套空调模板→验证→ DHT11 闭环→原始码学习兜底

注：后端"空调"能力模板(merge/电源/模式/温度/风速/扫风)与 ActuatorService merge 下发早已就绪，本次无需改动。固件不进 CI，以 PlatformIO 编译为准。

<!-- 感谢贡献！请填写以下信息，便于评审。 -->

## 这个 PR 做了什么

<!-- 简述动机与改动内容 -->

## 改动类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构 / 性能
- [ ] 文档
- [ ] 构建 / CI / 其他

## 自检清单

- [ ] 后端：`php -l` 通过，`composer test`（PHPUnit）通过
- [ ] 移动端（如涉及）：`npx tsc --noEmit` 与 `npm run build` 通过
- [ ] 已为新增/变更逻辑补充或更新测试（如适用）
- [ ] 已更新相关文档（README / 蓝图等）

## 部署影响

<!-- 是否需要：新数据库迁移 / 新环境变量 / 新进程 / 重新构建移动端？没有则写「无」 -->

## 关联 Issue

<!-- Closes #123 -->
